### PR TITLE
Revert "Expose Quorum to host machine for testing"

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,6 @@
 Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/xenial64"
   config.vm.provision :shell, path: "vagrant/bootstrap.sh"
-  config.vm.network :private_network, ip: "192.168.44.9"
   config.vm.provider "virtualbox" do |v|
     v.memory = 4096
   end

--- a/examples/7nodes/start.sh
+++ b/examples/7nodes/start.sh
@@ -5,7 +5,7 @@ NETID=87234
 BOOTNODE_KEYHEX=77bd02ffa26e3fb8f324bda24ae588066f1873d95680104de5bc2db9e7b2e510
 BOOTNODE_ENODE=enode://6433e8fb82c4638a8a6d499d40eb7d8158883219600bfd49acb968e3a37ccced04c964fa87b3a78a2da1b71dc1b90275f4d055720bb67fad4a118a56925125dc@[127.0.0.1]:33445
 
-GLOBAL_ARGS="--bootnodes $BOOTNODE_ENODE --networkid $NETID --rpc --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum"
+GLOBAL_ARGS="--bootnodes $BOOTNODE_ENODE --networkid $NETID "
 
 echo "[*] Starting Constellation nodes"
 nohup constellation-node tm1.conf 2>> qdata/logs/constellation1.log &
@@ -23,25 +23,25 @@ echo "wait for bootnode to start..."
 sleep 6
 
 echo "[*] Starting node 1"
-PRIVATE_CONFIG=tm1.conf nohup geth --datadir qdata/dd1 $GLOBAL_ARGS --rpcport 22000 --port 21000 --unlock 0 --password passwords.txt 2>>qdata/logs/1.log &
+PRIVATE_CONFIG=tm1.conf nohup geth --datadir qdata/dd1 $GLOBAL_ARGS --port 21000 --networkid $NETID --rpcport 22000 --rpc --unlock 0 --password passwords.txt 2>>qdata/logs/1.log &
 
 echo "[*] Starting node 2"
-PRIVATE_CONFIG=tm2.conf nohup geth --datadir qdata/dd2 $GLOBAL_ARGS --rpcport 22001 --port 21001 --voteaccount "0x0fbdc686b912d7722dc86510934589e0aaf3b55a" --votepassword "" --blockmakeraccount "0xca843569e3427144cead5e4d5999a3d0ccf92b8e" --blockmakerpassword "" --singleblockmaker --minblocktime 2 --maxblocktime 5 2>>qdata/logs/2.log &
+PRIVATE_CONFIG=tm2.conf nohup geth --datadir qdata/dd2 $GLOBAL_ARGS --voteaccount "0x0fbdc686b912d7722dc86510934589e0aaf3b55a" --votepassword "" --blockmakeraccount "0xca843569e3427144cead5e4d5999a3d0ccf92b8e" --blockmakerpassword "" --port 21001 --singleblockmaker --minblocktime 2 --maxblocktime 5 2>>qdata/logs/2.log &
 
 echo "[*] Starting node 3"
-PRIVATE_CONFIG=tm3.conf nohup geth --datadir qdata/dd3 $GLOBAL_ARGS --rpcport 22002 --port 21002 2>>qdata/logs/3.log &
+PRIVATE_CONFIG=tm3.conf nohup geth --datadir qdata/dd3 $GLOBAL_ARGS --port 21002 2>>qdata/logs/3.log &
 
 echo "[*] Starting node 4"
-PRIVATE_CONFIG=tm4.conf nohup geth --datadir qdata/dd4 $GLOBAL_ARGS --rpcport 22003 --port 21003 --voteaccount "0x9186eb3d20cbd1f5f992a950d808c4495153abd5" --votepassword "" 2>>qdata/logs/4.log &
+PRIVATE_CONFIG=tm4.conf nohup geth --datadir qdata/dd4 $GLOBAL_ARGS --voteaccount "0x9186eb3d20cbd1f5f992a950d808c4495153abd5" --votepassword "" --port 21003 2>>qdata/logs/4.log &
 
 echo "[*] Starting node 5"
-PRIVATE_CONFIG=tm5.conf nohup geth --datadir qdata/dd5 $GLOBAL_ARGS --rpcport 22004 --port 21004 --voteaccount "0x0638e1574728b6d862dd5d3a3e0942c3be47d996" --votepassword "" 2>>qdata/logs/5.log &
+PRIVATE_CONFIG=tm5.conf nohup geth --datadir qdata/dd5 $GLOBAL_ARGS --voteaccount "0x0638e1574728b6d862dd5d3a3e0942c3be47d996" --votepassword "" --port 21004 2>>qdata/logs/5.log &
 
 echo "[*] Starting node 6"
-PRIVATE_CONFIG=tm6.conf nohup geth --datadir qdata/dd6 $GLOBAL_ARGS --rpcport 22005 --port 21005 2>>qdata/logs/6.log &
+PRIVATE_CONFIG=tm6.conf nohup geth --datadir qdata/dd6 $GLOBAL_ARGS --port 21005 2>>qdata/logs/6.log &
 
 echo "[*] Starting node 7"
-PRIVATE_CONFIG=tm7.conf nohup geth --datadir qdata/dd7 $GLOBAL_ARGS --rpcport 22006 --port 21006 2>>qdata/logs/7.log &
+PRIVATE_CONFIG=tm7.conf nohup geth --datadir qdata/dd7 $GLOBAL_ARGS --port 21006 2>>qdata/logs/7.log &
 
 sleep 5
 echo "[*] Sending first transaction"


### PR DESCRIPTION
Reverts jpmorganchase/quorum-examples#3

This didn't work when testing on Windows:

F:\Downloads\quorum-examples-master>vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Importing base box 'ubuntu/xenial64'...
==> default: Matching MAC address for NAT networking...
==> default: Checking if box 'ubuntu/xenial64' is up to date...
==> default: A newer version of the box 'ubuntu/xenial64' is available! You currently
==> default: have version '20161109.1.0'. The latest is version '20161205.0.0'. Run
==> default: `vagrant box update` to update.
==> default: Setting the name of the VM: quorum-examples-master_default_1481011410335_49567
==> default: Clearing any previously set network interfaces...
There was an error while executing `VBoxManage`, a CLI used by Vagrant
for controlling VirtualBox. The command and stderr is shown below.

Command: ["hostonlyif", "create"]

Stderr: 0%...
Progress state: E_INVALIDARG
VBoxManage.exe: error: Failed to create the host-only adapter
VBoxManage.exe: error: Assertion failed: [!aInterfaceName.isEmpty()] at 'F:\tinderbox\win-5.1\src\VBox\Main\src-server\HostNetworkInterfaceImpl.cpp' (74) in long __cdecl HostNetworkInterface::init(class com::Bstr,class com::Bstr,class com::Guid,enum __MIDL___MIDL_itf_VirtualBox_0000_0000_0038).
VBoxManage.exe: error: Please contact the product vendor!
VBoxManage.exe: error: Details: code E_FAIL (0x80004005), component HostNetworkInterfaceWrap, interface IHostNetworkInterface
VBoxManage.exe: error: Context: "enum RTEXITCODE __cdecl handleCreate(struct HandlerArg *)" at line 71 of file VBoxManageHostonly.cpp