### PR TITLE
Fixing `raft-init.sh` script 💢

### DIFF
--- a/examples/7nodes/raft-init.sh
+++ b/examples/7nodes/raft-init.sh
@@ -19,7 +19,6 @@ mkdir -p qdata/dd2/{keystore,geth}
 cp permissioned-nodes.json qdata/dd2/static-nodes.json
 cp permissioned-nodes.json qdata/dd2/
 cp keys/key2 qdata/dd2/keystore
-cp keys/key3 qdata/dd2/keystore
 cp raft/nodekey2 qdata/dd2/geth/nodekey
 geth --datadir qdata/dd2 init genesis.json
 
@@ -27,6 +26,7 @@ echo "[*] Configuring node 3 (permissioned)"
 mkdir -p qdata/dd3/{keystore,geth}
 cp permissioned-nodes.json qdata/dd3/static-nodes.json
 cp permissioned-nodes.json qdata/dd3/
+cp keys/key3 qdata/dd3/keystore
 cp raft/nodekey3 qdata/dd3/geth/nodekey
 geth --datadir qdata/dd3 init genesis.json
 


### PR DESCRIPTION
The `raft-init.sh` script copies the keys for the third Quorum node to the `dd2` folder making the third node inaccessible. This PR should fix that.