### PR TITLE
EIP155 signer at start

### DIFF
--- a/examples/7nodes/genesis.json
+++ b/examples/7nodes/genesis.json
@@ -19,8 +19,9 @@
   "coinbase": "0x0000000000000000000000000000000000000000",
   "config": {
     "byzantiumBlock": 1,
-    "chainId": 1,
+    "chainId": 10,
     "eip150Block": 1,
+    "eip155Block": 0,
     "eip150Hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "eip158Block": 1,
     "isQuorum":true


### PR DESCRIPTION
Related change: https://github.com/jpmorganchase/quorum/pull/375 

Enable EIP155 signing scheme at the start; Change chain id to 10 to avoid conflict.
