### PR TITLE
Tessera HTTP readiness check on HTTP server itself

### DIFF
--- a/examples/7nodes/tessera-init.sh
+++ b/examples/7nodes/tessera-init.sh
@@ -5,11 +5,11 @@ echo "[*] Initialising Tessera configuration"
 currentDir=$(pwd)
 for i in {1..7}
 do
-    DDIR="qdata/c$i"
+    DDIR="${currentDir}/qdata/c${i}"
     mkdir -p ${DDIR}
     mkdir -p qdata/logs
-    cp "keys/tm$i.pub" "${DDIR}/tm.pub"
-    cp "keys/tm$i.key" "${DDIR}/tm.key"
+    cp "keys/tm${i}.pub" "${DDIR}/tm.pub"
+    cp "keys/tm${i}.key" "${DDIR}/tm.key"
     rm -f "${DDIR}/tm.ipc"
 
     #change tls to "strict" to enable it (don't forget to also change http -> https)
@@ -19,7 +19,7 @@ do
     "jdbc": {
         "username": "sa",
         "password": "",
-        "url": "jdbc:h2:./${DDIR}/db${i};MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0"
+        "url": "jdbc:h2:${DDIR}/db${i};MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0"
     },
     "server": {
         "port": 900${i},
@@ -27,18 +27,18 @@ do
         "sslConfig": {
             "tls": "OFF",
             "generateKeyStoreIfNotExisted": true,
-            "serverKeyStore": "${currentDir}/qdata/c${i}/server${i}-keystore",
+            "serverKeyStore": "${DDIR}/server${i}-keystore",
             "serverKeyStorePassword": "quorum",
-            "serverTrustStore": "${currentDir}/qdata/c${i}/server-truststore",
+            "serverTrustStore": "${DDIR}/server-truststore",
             "serverTrustStorePassword": "quorum",
             "serverTrustMode": "TOFU",
-            "knownClientsFile": "${currentDir}/qdata/c${i}/knownClients",
-            "clientKeyStore": "${currentDir}/qdata/c${i}/client${i}-keystore",
+            "knownClientsFile": "${DDIR}/knownClients",
+            "clientKeyStore": "${DDIR}/client${i}-keystore",
             "clientKeyStorePassword": "quorum",
-            "clientTrustStore": "${currentDir}/qdata/c${i}/client-truststore",
+            "clientTrustStore": "${DDIR}/client-truststore",
             "clientTrustStorePassword": "quorum",
             "clientTrustMode": "TOFU",
-            "knownServersFile": "${currentDir}/qdata/c${i}/knownServers"
+            "knownServersFile": "${DDIR}/knownServers"
         }
     },
     "peer": [
@@ -68,13 +68,13 @@ do
         "passwords": [],
         "keyData": [
             {
-                "config": $(cat ${currentDir}/qdata/c${i}/tm.key),
-                "publicKey": "$(cat ${currentDir}/qdata/c${i}/tm.pub)"
+                "privateKeyPath": "${DDIR}/tm.key",
+                "publicKeyPath": "${DDIR}/tm.pub"
             }
         ]
     },
     "alwaysSendTo": [],
-    "unixSocketFile": "${currentDir}/qdata/c${i}/tm.ipc"
+    "unixSocketFile": "${DDIR}/tm.ipc"
 }
 EOF
 

--- a/examples/7nodes/tessera-start.sh
+++ b/examples/7nodes/tessera-start.sh
@@ -102,7 +102,8 @@ while ${DOWN}; do
         fi
 
         set +e
-        result=$(printf 'GET /upcheck HTTP/1.0\r\n\r\n' | nc -Uv qdata/c${i}/tm.ipc | tail -n 1)
+        #note that the "http://c" scheme and host is irrelevant, but cURL needs a valid uri to work
+        result=$(curl -s --connect-timeout 1 --unix-socket qdata/c${i}/tm.ipc http://c/upcheck)
         set -e
         if [ ! "${result}" == "I'm up!" ]; then
             echo "Node ${i} is not yet listening on http"

--- a/examples/7nodes/tessera-start.sh
+++ b/examples/7nodes/tessera-start.sh
@@ -102,8 +102,9 @@ while ${DOWN}; do
         fi
 
         set +e
-        #note that the "http://c" scheme and host is irrelevant, but cURL needs a valid uri to work
-        result=$(curl -s --connect-timeout 1 --unix-socket qdata/c${i}/tm.ipc http://c/upcheck)
+        #NOTE: if using https, change the scheme
+        #NOTE: if using the IP whitelist, change the host to an allowed host
+        result=$(curl -s --connect-timeout 1 qdata/c${i}/tm.ipc http://localhost:900${i}/upcheck)
         set -e
         if [ ! "${result}" == "I'm up!" ]; then
             echo "Node ${i} is not yet listening on http"

--- a/examples/7nodes/tessera-start.sh
+++ b/examples/7nodes/tessera-start.sh
@@ -104,7 +104,7 @@ while ${DOWN}; do
         set +e
         #NOTE: if using https, change the scheme
         #NOTE: if using the IP whitelist, change the host to an allowed host
-        result=$(curl -s --connect-timeout 1 qdata/c${i}/tm.ipc http://localhost:900${i}/upcheck)
+        result=$(curl -s http://localhost:900${i}/upcheck)
         set -e
         if [ ! "${result}" == "I'm up!" ]; then
             echo "Node ${i} is not yet listening on http"


### PR DESCRIPTION
Currently the check to see if the HTTP server is ready is to send a request via the unix socket (which reroutes to the HTTP server), whereas it is more obvious and straightforward to query the HTTP server directly.

Also consolidated paths in the Tessera configuration init script.