### PR TITLE
Docker support to bring up 7nodes example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ demonstration and testing purposes only. Before running a real environment, you 
 generate new ones using Geth's `account` tool and the `--generate-keys` option for Constellation (or `-keygen` option for Tessera).
 
 ## Getting Started
-The 7nodes example can be run in two ways:
+The 7nodes example can be run in three ways:
 1. By running a preconfigured Vagrant environment which comes complete with Quorum, Constellation, Tessera and the 7nodes example (__works on any machine__).
-2. By downloading and locally running Quorum, Tessera and the examples (__requires an Ubuntu-based/macOS machine; note that Constellation does not support running locally__) 
+1. By running [`docker-compose`](https://docs.docker.com/compose/) against a preconfigured [compose file](docker-compose.yml) which starts 7nodes example (__works on any machine__).
+1. By downloading and locally running Quorum, Tessera and the examples (__requires an Ubuntu-based/macOS machine; note that Constellation does not support running locally__)
 
 ### Setting up Vagrant
 1. Install [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
@@ -28,7 +29,7 @@ The 7nodes example can be run in two ways:
     vagrant up
     vagrant ssh
     ```
-    
+
 4. To shutdown the Vagrant instance, run `vagrant suspend`. To delete it, run
    `vagrant destroy`. To start from scratch, run `vagrant up` after destroying the
    instance.
@@ -44,9 +45,43 @@ issues with the version of curl bundled with Vagrant.
 * The Vagrant instance is allocated 6 GB of memory.  This is defined in the `Vagrantfile`, `v.memory = 6144`.  This has been deemed a suitable value to allow the VM and examples to run as expected.  The memory allocation can be changed by updating this value and running `vagrant reload` to apply the change.
 
 * If the machine you are using has less than 8 GB memory you will likely encounter system issues such as slow down and unresponsiveness when starting the Vagrant instance as your machine will not have the capacity to run the VM.  There are several steps that can be taken to overcome this:
-    1. Shutdown any running processes that are not required 
+    1. Shutdown any running processes that are not required
     1. If running the [7nodes example](examples/7nodes), reduce the number of nodes started up.  See the [7nodes README: Reducing the number of nodes](examples/7nodes/README.md#reducing-the-number-of-nodes) for info on how to do this.
     1. Set up and run the examples locally.  Running locally reduces the load on your memory compared to running in Vagrant.
+
+### Setting up Docker
+
+1. Install Docker (https://www.docker.com/get-started)
+   * If your Docker distribution does not contain `docker-compose`, follow [this](https://docs.docker.com/compose/install/) to install Docker Compose
+  * Make sure your Docker daemon has at least 4G memory
+1. Download and run `docker-compose`
+  ```sh
+  git clone https://github.com/jpmorganchase/quorum-examples
+  cd quorum-examples
+  docker-compose up -d
+  ```
+1. By default, Quorum Network is created using Tessera transaction manager and Istanbul BFT consensus. If you wish to change consensus configuration to Raft, set the environment variable `QUORUM_CONSENSUS=raft` before running `docker-compose`
+  ```sh
+  QUORUM_CONSENSUS=raft docker-compose up -d
+  ```
+1. Run `docker ps` to verify that all quorum-examples containers (7 nodes and 7 tx managers) are **healthy**
+1. __Note__: to run the 7nodes demo, use the following snippet to open `geth` Javascript console to a desired node (using container name from `docker ps`) and send a private transaction
+  ```sh
+  $ docker exec -it quorum-examples_node1_1 geth attach /qdata/dd/geth.ipc
+  Welcome to the Geth JavaScript console!
+
+  instance: Geth/node1-istanbul/v1.7.2-stable/linux-amd64/go1.9.7
+  coinbase: 0xd8dba507e85f116b1f7e231ca8525fc9008a6966
+  at block: 70 (Thu, 18 Oct 2018 14:49:47 UTC)
+   datadir: /qdata/dd
+   modules: admin:1.0 debug:1.0 eth:1.0 istanbul:1.0 miner:1.0 net:1.0 personal:1.0 rpc:1.0 txpool:1.0 web3:1.0
+
+  > loadScript('/examples/private-contract.js')
+  ```
+1. Shutdown Quorum Network
+  ```sh
+  docker-compose down
+  ```
 
 ### Setting up locally
 > This is only possible with Tessera. Constellation is not supported when running the examples locally. To use Constellation, the examples must be run in Vagrant.
@@ -88,14 +123,14 @@ All logs and temporary data are written to the `qdata` folder.
         ./raft-start.sh tessera
         ```
         By default, `raft-start.sh` will look in `/home/vagrant/tessera/tessera-app/target/tessera-app-{version}-app.jar` for the Tessera jar.
-    
+
     - If running locally with Tessera:
         ```
         ./raft-start.sh tessera --tesseraOptions "--tesseraJar /path/to/tessera-app.jar"
-        ``` 
-    
+        ```
+
         The Tessera jar location can also be specified by setting the environment variable `TESSERA_JAR`.
-    
+
 3. You are now ready to start sending private/public transactions between the nodes
 
 #### Using Istanbul BFT consensus

--- a/README.md
+++ b/README.md
@@ -53,35 +53,35 @@ issues with the version of curl bundled with Vagrant.
 
 1. Install Docker (https://www.docker.com/get-started)
    * If your Docker distribution does not contain `docker-compose`, follow [this](https://docs.docker.com/compose/install/) to install Docker Compose
-  * Make sure your Docker daemon has at least 4G memory
+   * Make sure your Docker daemon has at least 4G memory
 1. Download and run `docker-compose`
-  ```sh
-  git clone https://github.com/jpmorganchase/quorum-examples
-  cd quorum-examples
-  docker-compose up -d
-  ```
+   ```sh
+   git clone https://github.com/jpmorganchase/quorum-examples
+   cd quorum-examples
+   docker-compose up -d
+   ```
 1. By default, Quorum Network is created using Tessera transaction manager and Istanbul BFT consensus. If you wish to change consensus configuration to Raft, set the environment variable `QUORUM_CONSENSUS=raft` before running `docker-compose`
-  ```sh
-  QUORUM_CONSENSUS=raft docker-compose up -d
-  ```
+   ```sh
+   QUORUM_CONSENSUS=raft docker-compose up -d
+   ```
 1. Run `docker ps` to verify that all quorum-examples containers (7 nodes and 7 tx managers) are **healthy**
 1. __Note__: to run the 7nodes demo, use the following snippet to open `geth` Javascript console to a desired node (using container name from `docker ps`) and send a private transaction
-  ```sh
-  $ docker exec -it quorum-examples_node1_1 geth attach /qdata/dd/geth.ipc
-  Welcome to the Geth JavaScript console!
+   ```sh
+   $ docker exec -it quorum-examples_node1_1 geth attach /qdata/dd/geth.ipc
+   Welcome to the Geth JavaScript console!
 
-  instance: Geth/node1-istanbul/v1.7.2-stable/linux-amd64/go1.9.7
-  coinbase: 0xd8dba507e85f116b1f7e231ca8525fc9008a6966
-  at block: 70 (Thu, 18 Oct 2018 14:49:47 UTC)
-   datadir: /qdata/dd
-   modules: admin:1.0 debug:1.0 eth:1.0 istanbul:1.0 miner:1.0 net:1.0 personal:1.0 rpc:1.0 txpool:1.0 web3:1.0
+   instance: Geth/node1-istanbul/v1.7.2-stable/linux-amd64/go1.9.7
+   coinbase: 0xd8dba507e85f116b1f7e231ca8525fc9008a6966
+   at block: 70 (Thu, 18 Oct 2018 14:49:47 UTC)
+    datadir: /qdata/dd
+    modules: admin:1.0 debug:1.0 eth:1.0 istanbul:1.0 miner:1.0 net:1.0 personal:1.0 rpc:1.0 txpool:1.0 web3:1.0
 
-  > loadScript('/examples/private-contract.js')
-  ```
+   > loadScript('/examples/private-contract.js')
+   ```
 1. Shutdown Quorum Network
-  ```sh
-  docker-compose down
-  ```
+   ```sh
+   docker-compose down
+   ```
 
 ### Setting up locally
 > This is only possible with Tessera. Constellation is not supported when running the examples locally. To use Constellation, the examples must be run in Vagrant.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,339 @@
+# The following environment variables are substituted if present
+# * CONSENSUS: default to raft
+# * QUORUM_DOCKER_IMAGE: default to quorumengineering/quorum:latest
+# * TX_MANAGER_DOCKER_IMAGE: default to quorumengineering/tessera:latest
+version: "3.6"
+x-quorum-def:
+  &quorum-def
+  restart: "no"
+  image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:latest}"
+  expose:
+    - "30303"
+    - "50401"
+  entrypoint:
+    - /bin/sh
+    - -c
+    - |
+      while [ ! -S /qdata/tm/tm.ipc ]; do
+        echo "Waiting for tx engine to be up"
+        sleep 3
+      done
+      DDIR=/qdata/dd
+      rm -rf $${DDIR}
+      mkdir -p $${DDIR}/keystore
+      mkdir -p $${DDIR}/geth
+      cp /config/raft/nodekey$${NODE_ID} $${DDIR}/geth/nodekey
+      cp /config/keys/key1 $${DDIR}/keystore/
+      cp /config/permissioned-nodes.json $${DDIR}/static-nodes.json
+      NETWORK_ID=$$(cat /config/genesis.json | grep chainId | awk -F " " '{print $$2}' | awk -F "," '{print $$1}')
+      geth --datadir $${DDIR} init /config/genesis.json
+      geth \
+        --identity node$${NODE_ID} \
+        --datadir $${DDIR} \
+        --permissioned \
+        --nodiscover \
+        --verbosity 5 \
+        --networkid $$NETWORK_ID \
+        --raft \
+        --rpc \
+        --rpcaddr 0.0.0.0 \
+        --rpcport 8545 \
+        --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft \
+        --emitcheckpoints \
+        --raftport 50401 \
+        --port 30303 \
+        --unlock 0 \
+        --password /config/passwords.txt
+x-tx-engine-def:
+  &tx-engine-def
+  image: "${TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:latest}"
+  expose:
+    - "9000"
+  restart: "no"
+  entrypoint:
+    - /bin/sh
+    - -c
+    - |
+      apk update
+      apk add curl
+      DDIR=/qdata/tm
+      rm -rf $${DDIR}
+      mkdir -p $${DDIR}
+      cp /config/keys/tm$${NODE_ID}.pub $${DDIR}/tm.pub
+      cp /config/keys/tm$${NODE_ID}.key $${DDIR}/tm.key
+      cat <<EOF > $${DDIR}/tessera-config.json
+      {
+          "useWhiteList": false,
+          "jdbc": {
+              "username": "sa",
+              "password": "",
+              "url": "jdbc:h2:./$${DDIR}/db;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0"
+          },
+          "server": {
+              "port": 9000,
+              "hostName": "http://$$(hostname -i)",
+              "sslConfig": {
+                  "tls": "OFF",
+                  "generateKeyStoreIfNotExisted": true,
+                  "serverKeyStore": "$${DDIR}/server-keystore",
+                  "serverKeyStorePassword": "quorum",
+                  "serverTrustStore": "$${DDIR}/server-truststore",
+                  "serverTrustStorePassword": "quorum",
+                  "serverTrustMode": "TOFU",
+                  "knownClientsFile": "$${DDIR}/knownClients",
+                  "clientKeyStore": "$${DDIR}/client-keystore",
+                  "clientKeyStorePassword": "quorum",
+                  "clientTrustStore": "$${DDIR}/client-truststore",
+                  "clientTrustStorePassword": "quorum",
+                  "clientTrustMode": "TOFU",
+                  "knownServersFile": "$${DDIR}/knownServers"
+              }
+          },
+          "peer": [
+              {
+                  "url": "http://172.16.239.101:9000"
+              },
+              {
+                  "url": "http://172.16.239.102:9000"
+              },
+              {
+                  "url": "http://172.16.239.103:9000"
+              },
+              {
+                  "url": "http://172.16.239.104:9000"
+              },
+              {
+                  "url": "http://172.16.239.105:9000"
+              },
+              {
+                  "url": "http://172.16.239.106:9000"
+              },
+              {
+                  "url": "http://172.16.239.107:9000"
+              }
+          ],
+          "keys": {
+              "passwords": [],
+              "keyData": [
+                  {
+                      "config": $$(cat $${DDIR}/tm.key),
+                      "publicKey": "$$(cat $${DDIR}/tm.pub)"
+                  }
+              ]
+          },
+          "alwaysSendTo": [],
+          "unixSocketFile": "$${DDIR}/tm.ipc"
+      }
+      EOF
+      java -jar /tessera/tessera-app.jar -configfile $${DDIR}/tessera-config.json
+  healthcheck:
+    test: ["CMD", "curl", "-f", "http://localhost:9000/upcheck"]
+    interval: 3s
+    timeout: 30s
+    retries: 10
+    start_period: 5s
+services:
+  node1:
+    << : *quorum-def
+    hostname: node1
+    ports:
+      - "22001:8545"
+    volumes:
+      - 1:/qdata
+      - ./examples/7nodes:/config
+    depends_on:
+      - tx-manager-1
+    environment:
+      - PRIVATE_CONFIG=/qdata/tm/tm.ipc
+      - NODE_ID=1
+    networks:
+      quorum-examples-net:
+        ipv4_address: 172.16.239.11
+  node2:
+    << : *quorum-def
+    hostname: node2
+    ports:
+      - "22002:8545"
+    volumes:
+      - 2:/qdata
+      - ./examples/7nodes:/config
+    depends_on:
+      - tx-manager-2
+    environment:
+      - PRIVATE_CONFIG=/qdata/tm/tm.ipc
+      - NODE_ID=2
+    networks:
+      quorum-examples-net:
+        ipv4_address: 172.16.239.12
+  node3:
+    << : *quorum-def
+    hostname: node3
+    ports:
+      - "22003:8545"
+    volumes:
+      - 3:/qdata
+      - ./examples/7nodes:/config
+    depends_on:
+      - tx-manager-3
+    environment:
+      - PRIVATE_CONFIG=/qdata/tm/tm.ipc
+      - NODE_ID=3
+    networks:
+      quorum-examples-net:
+        ipv4_address: 172.16.239.13
+  node4:
+    << : *quorum-def
+    hostname: node4
+    ports:
+      - "22004:8545"
+    volumes:
+      - 4:/qdata
+      - ./examples/7nodes:/config
+    depends_on:
+      - tx-manager-4
+    environment:
+      - PRIVATE_CONFIG=/qdata/tm/tm.ipc
+      - NODE_ID=4
+    networks:
+      quorum-examples-net:
+        ipv4_address: 172.16.239.14
+  node5:
+    << : *quorum-def
+    hostname: node5
+    ports:
+      - "22005:8545"
+    volumes:
+      - 5:/qdata
+      - ./examples/7nodes:/config
+    depends_on:
+      - tx-manager-5
+    environment:
+      - PRIVATE_CONFIG=/qdata/tm/tm.ipc
+      - NODE_ID=5
+    networks:
+      quorum-examples-net:
+        ipv4_address: 172.16.239.15
+  node6:
+    << : *quorum-def
+    hostname: node6
+    ports:
+      - "22006:8545"
+    volumes:
+      - 6:/qdata
+      - ./examples/7nodes:/config
+    depends_on:
+      - tx-manager-6
+    environment:
+      - PRIVATE_CONFIG=/qdata/tm/tm.ipc
+      - NODE_ID=6
+    networks:
+      quorum-examples-net:
+        ipv4_address: 172.16.239.16
+  node7:
+    << : *quorum-def
+    hostname: node7
+    ports:
+      - "22007:8545"
+    volumes:
+      - 7:/qdata
+      - ./examples/7nodes:/config
+    depends_on:
+      - tx-manager-7
+    environment:
+      - PRIVATE_CONFIG=/qdata/tm/tm.ipc
+      - NODE_ID=7
+    networks:
+      quorum-examples-net:
+        ipv4_address: 172.16.239.17
+  tx-manager-1:
+    << : *tx-engine-def
+    hostname: tx-manager-1
+    volumes:
+      - 1:/qdata
+      - ./examples/7nodes:/config
+    networks:
+      quorum-examples-net:
+        ipv4_address: 172.16.239.101
+    environment:
+      - NODE_ID=1
+  tx-manager-2:
+    << : *tx-engine-def
+    hostname: tx-manager-2
+    volumes:
+      - 2:/qdata:z
+      - ./examples/7nodes:/config
+    networks:
+      quorum-examples-net:
+        ipv4_address: 172.16.239.102
+    environment:
+      - NODE_ID=2
+  tx-manager-3:
+    << : *tx-engine-def
+    hostname: tx-manager-3
+    volumes:
+      - 3:/qdata:z
+      - ./examples/7nodes:/config
+    networks:
+      quorum-examples-net:
+        ipv4_address: 172.16.239.103
+    environment:
+      - NODE_ID=3
+  tx-manager-4:
+    << : *tx-engine-def
+    hostname: tx-manager-4
+    volumes:
+      - 4:/qdata:z
+      - ./examples/7nodes:/config
+    networks:
+      quorum-examples-net:
+        ipv4_address: 172.16.239.104
+    environment:
+      - NODE_ID=4
+  tx-manager-5:
+    << : *tx-engine-def
+    hostname: tx-manager-5
+    volumes:
+      - 5:/qdata:z
+      - ./examples/7nodes:/config
+    networks:
+      quorum-examples-net:
+        ipv4_address: 172.16.239.105
+    environment:
+      - NODE_ID=5
+  tx-manager-6:
+    << : *tx-engine-def
+    hostname: tx-manager-6
+    volumes:
+      - 6:/qdata:z
+      - ./examples/7nodes:/config
+    networks:
+      quorum-examples-net:
+        ipv4_address: 172.16.239.106
+    environment:
+      - NODE_ID=6
+  tx-manager-7:
+    << : *tx-engine-def
+    hostname: tx-manager-7
+    volumes:
+      - 7:/qdata:z
+      - ./examples/7nodes:/config
+    networks:
+      quorum-examples-net:
+        ipv4_address: 172.16.239.107
+    environment:
+      - NODE_ID=7
+networks:
+  quorum-examples-net:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+      - subnet: 172.16.239.0/24
+volumes:
+  "1":
+  "2":
+  "3":
+  "4":
+  "5":
+  "6":
+  "7":

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,31 +2,29 @@
 # * CONSENSUS: default to raft
 # * QUORUM_DOCKER_IMAGE: default to quorumengineering/quorum:latest
 # * TX_MANAGER_DOCKER_IMAGE: default to quorumengineering/tessera:latest
-version: "3.6"
+version: "3.7"
 x-quorum-def:
   &quorum-def
-  restart: "no"
+  restart: "on-failure"
   image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:latest}"
   expose:
-    - "30303"
-    - "50401"
+    - "21000"
+    - "50400"
   entrypoint:
     - /bin/sh
     - -c
     - |
-      while [ ! -S /qdata/tm/tm.ipc ]; do
-        echo "Waiting for tx engine to be up"
-        sleep 3
-      done
       DDIR=/qdata/dd
       rm -rf $${DDIR}
       mkdir -p $${DDIR}/keystore
       mkdir -p $${DDIR}/geth
       cp /config/raft/nodekey$${NODE_ID} $${DDIR}/geth/nodekey
       cp /config/keys/key1 $${DDIR}/keystore/
-      cp /config/permissioned-nodes.json $${DDIR}/static-nodes.json
-      NETWORK_ID=$$(cat /config/genesis.json | grep chainId | awk -F " " '{print $$2}' | awk -F "," '{print $$1}')
-      geth --datadir $${DDIR} init /config/genesis.json
+      cat /config/permissioned-nodes.json | sed 's/^\(.*\)@.*\?\(.*\)raftport=5040\([0-9]\)\(.*\)$$/\1@172.16.239.1\3:21000?discport=0\4/g' > $${DDIR}/static-nodes.json
+      cp $${DDIR}/static-nodes.json $${DDIR}/permissioned-nodes.json
+      cat $${DDIR}/static-nodes.json
+      NETWORK_ID=$$(cat /config/istanbul-genesis.json | grep chainId | awk -F " " '{print $$2}' | awk -F "," '{print $$1}')
+      geth --datadir $${DDIR} init /config/istanbul-genesis.json
       geth \
         --identity node$${NODE_ID} \
         --datadir $${DDIR} \
@@ -34,18 +32,20 @@ x-quorum-def:
         --nodiscover \
         --verbosity 5 \
         --networkid $$NETWORK_ID \
-        --raft \
         --rpc \
         --rpcaddr 0.0.0.0 \
         --rpcport 8545 \
-        --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft \
+        --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul \
         --emitcheckpoints \
-        --raftport 50401 \
-        --port 30303 \
+        --port 21000 \
         --unlock 0 \
-        --password /config/passwords.txt
-x-tx-engine-def:
-  &tx-engine-def
+        --password /config/passwords.txt \
+        --istanbul.blockperiod 1 \
+        --mine \
+        --minerthreads 1 \
+        --syncmode full
+x-tx-manager-tessera-def:
+  &tx-manager-tessera-def
   image: "${TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:latest}"
   expose:
     - "9000"
@@ -54,8 +54,6 @@ x-tx-engine-def:
     - /bin/sh
     - -c
     - |
-      apk update
-      apk add curl
       DDIR=/qdata/tm
       rm -rf $${DDIR}
       mkdir -p $${DDIR}
@@ -91,25 +89,25 @@ x-tx-engine-def:
           },
           "peer": [
               {
-                  "url": "http://172.16.239.101:9000"
+                  "url": "http://txmanager1:9000"
               },
               {
-                  "url": "http://172.16.239.102:9000"
+                  "url": "http://txmanager2:9000"
               },
               {
-                  "url": "http://172.16.239.103:9000"
+                  "url": "http://txmanager3:9000"
               },
               {
-                  "url": "http://172.16.239.104:9000"
+                  "url": "http://txmanager4:9000"
               },
               {
-                  "url": "http://172.16.239.105:9000"
+                  "url": "http://txmanager5:9000"
               },
               {
-                  "url": "http://172.16.239.106:9000"
+                  "url": "http://txmanager6:9000"
               },
               {
-                  "url": "http://172.16.239.107:9000"
+                  "url": "http://txmanager7:9000"
               }
           ],
           "keys": {
@@ -125,13 +123,30 @@ x-tx-engine-def:
           "unixSocketFile": "$${DDIR}/tm.ipc"
       }
       EOF
-      java -jar /tessera/tessera-app.jar -configfile $${DDIR}/tessera-config.json
-  healthcheck:
-    test: ["CMD", "curl", "-f", "http://localhost:9000/upcheck"]
-    interval: 3s
-    timeout: 30s
-    retries: 10
-    start_period: 5s
+      java -Xms128M -Xmx128M -jar /tessera/tessera-app.jar -configfile $${DDIR}/tessera-config.json
+x-tx-manager-constellation-def:
+  &tx-manager-constellation-def
+  image: "${TX_MANAGER_DOCKER_IMAGE:-quorumengineering/constellation:latest}"
+  expose:
+    - "9000"
+  restart: "no"
+  entrypoint:
+    - /bin/sh
+    - -c
+    - |
+      DDIR=/qdata/tm
+      rm -rf $${DDIR}
+      mkdir -p $${DDIR}
+      echo "socket=\"$${DDIR}/tm.ipc\"\npublickeys=[\"/config/keys/tm$${NODE_ID}.pub\"]\n" > $${DDIR}/tm.conf
+      constellation-node \
+        --url=http://$$(hostname -i):9000/ \
+        --port=9000 \
+        --socket=$${DDIR}/tm.ipc \
+        --othernodes=http://172.16.239.101:9000/,http://172.16.239.102:9000/,http://172.16.239.103:9000/,http://172.16.239.104:9000/,http://172.16.239.105:9000/ \
+        --publickeys=/config/keys/tm$${NODE_ID}.pub \
+        --privatekeys=/config/keys/tm$${NODE_ID}.key \
+        --storage=$${DDIR} \
+        --verbosity=4
 services:
   node1:
     << : *quorum-def
@@ -140,15 +155,26 @@ services:
       - "22001:8545"
     volumes:
       - 1:/qdata
-      - ./examples/7nodes:/config
+      - ./examples/7nodes:/config:ro
     depends_on:
-      - tx-manager-1
+      - txmanager1
     environment:
       - PRIVATE_CONFIG=/qdata/tm/tm.ipc
       - NODE_ID=1
     networks:
       quorum-examples-net:
         ipv4_address: 172.16.239.11
+  txmanager1:
+    << : *tx-manager-tessera-def
+    hostname: txmanager1
+    volumes:
+      - 1:/qdata
+      - ./examples/7nodes:/config:ro
+    networks:
+      quorum-examples-net:
+        ipv4_address: 172.16.239.101
+    environment:
+      - NODE_ID=1
   node2:
     << : *quorum-def
     hostname: node2
@@ -156,15 +182,26 @@ services:
       - "22002:8545"
     volumes:
       - 2:/qdata
-      - ./examples/7nodes:/config
+      - ./examples/7nodes:/config:ro
     depends_on:
-      - tx-manager-2
+      - txmanager2
     environment:
       - PRIVATE_CONFIG=/qdata/tm/tm.ipc
       - NODE_ID=2
     networks:
       quorum-examples-net:
         ipv4_address: 172.16.239.12
+  txmanager2:
+    << : *tx-manager-tessera-def
+    hostname: txmanager2
+    volumes:
+      - 2:/qdata
+      - ./examples/7nodes:/config:ro
+    networks:
+      quorum-examples-net:
+        ipv4_address: 172.16.239.102
+    environment:
+      - NODE_ID=2
   node3:
     << : *quorum-def
     hostname: node3
@@ -172,15 +209,26 @@ services:
       - "22003:8545"
     volumes:
       - 3:/qdata
-      - ./examples/7nodes:/config
+      - ./examples/7nodes:/config:ro
     depends_on:
-      - tx-manager-3
+      - txmanager3
     environment:
       - PRIVATE_CONFIG=/qdata/tm/tm.ipc
       - NODE_ID=3
     networks:
       quorum-examples-net:
         ipv4_address: 172.16.239.13
+  txmanager3:
+    << : *tx-manager-tessera-def
+    hostname: txmanager3
+    volumes:
+      - 3:/qdata
+      - ./examples/7nodes:/config:ro
+    networks:
+      quorum-examples-net:
+        ipv4_address: 172.16.239.103
+    environment:
+      - NODE_ID=3
   node4:
     << : *quorum-def
     hostname: node4
@@ -188,15 +236,26 @@ services:
       - "22004:8545"
     volumes:
       - 4:/qdata
-      - ./examples/7nodes:/config
+      - ./examples/7nodes:/config:ro
     depends_on:
-      - tx-manager-4
+      - txmanager4
     environment:
       - PRIVATE_CONFIG=/qdata/tm/tm.ipc
       - NODE_ID=4
     networks:
       quorum-examples-net:
         ipv4_address: 172.16.239.14
+  txmanager4:
+    << : *tx-manager-tessera-def
+    hostname: txmanager4
+    volumes:
+      - 4:/qdata
+      - ./examples/7nodes:/config:ro
+    networks:
+      quorum-examples-net:
+        ipv4_address: 172.16.239.104
+    environment:
+      - NODE_ID=4
   node5:
     << : *quorum-def
     hostname: node5
@@ -204,15 +263,26 @@ services:
       - "22005:8545"
     volumes:
       - 5:/qdata
-      - ./examples/7nodes:/config
+      - ./examples/7nodes:/config:ro
     depends_on:
-      - tx-manager-5
+      - txmanager5
     environment:
       - PRIVATE_CONFIG=/qdata/tm/tm.ipc
       - NODE_ID=5
     networks:
       quorum-examples-net:
         ipv4_address: 172.16.239.15
+  txmanager5:
+    << : *tx-manager-tessera-def
+    hostname: txmanager5
+    volumes:
+      - 5:/qdata
+      - ./examples/7nodes:/config:ro
+    networks:
+      quorum-examples-net:
+        ipv4_address: 172.16.239.105
+    environment:
+      - NODE_ID=5
   node6:
     << : *quorum-def
     hostname: node6
@@ -220,15 +290,26 @@ services:
       - "22006:8545"
     volumes:
       - 6:/qdata
-      - ./examples/7nodes:/config
+      - ./examples/7nodes:/config:ro
     depends_on:
-      - tx-manager-6
+      - txmanager6
     environment:
       - PRIVATE_CONFIG=/qdata/tm/tm.ipc
       - NODE_ID=6
     networks:
       quorum-examples-net:
         ipv4_address: 172.16.239.16
+  txmanager6:
+    << : *tx-manager-tessera-def
+    hostname: txmanager6
+    volumes:
+      - 6:/qdata
+      - ./examples/7nodes:/config:ro
+    networks:
+      quorum-examples-net:
+        ipv4_address: 172.16.239.106
+    environment:
+      - NODE_ID=6
   node7:
     << : *quorum-def
     hostname: node7
@@ -236,87 +317,21 @@ services:
       - "22007:8545"
     volumes:
       - 7:/qdata
-      - ./examples/7nodes:/config
+      - ./examples/7nodes:/config:ro
     depends_on:
-      - tx-manager-7
+      - txmanager7
     environment:
       - PRIVATE_CONFIG=/qdata/tm/tm.ipc
       - NODE_ID=7
     networks:
       quorum-examples-net:
         ipv4_address: 172.16.239.17
-  tx-manager-1:
-    << : *tx-engine-def
-    hostname: tx-manager-1
+  txmanager7:
+    << : *tx-manager-tessera-def
+    hostname: txmanager7
     volumes:
-      - 1:/qdata
-      - ./examples/7nodes:/config
-    networks:
-      quorum-examples-net:
-        ipv4_address: 172.16.239.101
-    environment:
-      - NODE_ID=1
-  tx-manager-2:
-    << : *tx-engine-def
-    hostname: tx-manager-2
-    volumes:
-      - 2:/qdata:z
-      - ./examples/7nodes:/config
-    networks:
-      quorum-examples-net:
-        ipv4_address: 172.16.239.102
-    environment:
-      - NODE_ID=2
-  tx-manager-3:
-    << : *tx-engine-def
-    hostname: tx-manager-3
-    volumes:
-      - 3:/qdata:z
-      - ./examples/7nodes:/config
-    networks:
-      quorum-examples-net:
-        ipv4_address: 172.16.239.103
-    environment:
-      - NODE_ID=3
-  tx-manager-4:
-    << : *tx-engine-def
-    hostname: tx-manager-4
-    volumes:
-      - 4:/qdata:z
-      - ./examples/7nodes:/config
-    networks:
-      quorum-examples-net:
-        ipv4_address: 172.16.239.104
-    environment:
-      - NODE_ID=4
-  tx-manager-5:
-    << : *tx-engine-def
-    hostname: tx-manager-5
-    volumes:
-      - 5:/qdata:z
-      - ./examples/7nodes:/config
-    networks:
-      quorum-examples-net:
-        ipv4_address: 172.16.239.105
-    environment:
-      - NODE_ID=5
-  tx-manager-6:
-    << : *tx-engine-def
-    hostname: tx-manager-6
-    volumes:
-      - 6:/qdata:z
-      - ./examples/7nodes:/config
-    networks:
-      quorum-examples-net:
-        ipv4_address: 172.16.239.106
-    environment:
-      - NODE_ID=6
-  tx-manager-7:
-    << : *tx-engine-def
-    hostname: tx-manager-7
-    volumes:
-      - 7:/qdata:z
-      - ./examples/7nodes:/config
+      - 7:/qdata
+      - ./examples/7nodes:/config:ro
     networks:
       quorum-examples-net:
         ipv4_address: 172.16.239.107

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # The following environment variables are substituted if present
-# * CONSENSUS: default to raft
+# * QUORUM_CONSENSUS: default to istanbul
 # * QUORUM_DOCKER_IMAGE: default to quorumengineering/quorum:latest
-# * TX_MANAGER_DOCKER_IMAGE: default to quorumengineering/tessera:latest
+# * QUORUM_QUORUM_TX_MANAGER_DOCKER_IMAGE: default to quorumengineering/tessera:latest
 version: "3.7"
 x-quorum-def:
   &quorum-def
@@ -10,6 +10,14 @@ x-quorum-def:
   expose:
     - "21000"
     - "50400"
+  healthcheck:
+    test: ["CMD", "wget", "--spider", "http://localhost:8545"]
+    interval: 3s
+    timeout: 3s
+    retries: 10
+    start_period: 5s
+  labels:
+    com.quorum.consensus: ${QUORUM_CONSENSUS:-istanbul}
   entrypoint:
     - /bin/sh
     - -c
@@ -18,38 +26,46 @@ x-quorum-def:
       rm -rf $${DDIR}
       mkdir -p $${DDIR}/keystore
       mkdir -p $${DDIR}/geth
-      cp /config/raft/nodekey$${NODE_ID} $${DDIR}/geth/nodekey
-      cp /config/keys/key1 $${DDIR}/keystore/
-      cat /config/permissioned-nodes.json | sed 's/^\(.*\)@.*\?\(.*\)raftport=5040\([0-9]\)\(.*\)$$/\1@172.16.239.1\3:21000?discport=0\4/g' > $${DDIR}/static-nodes.json
+      cp /examples/raft/nodekey$${NODE_ID} $${DDIR}/geth/nodekey
+      cp /examples/keys/key1 $${DDIR}/keystore/
+      cat /examples/permissioned-nodes.json | sed 's/^\(.*\)@.*\?\(.*\)raftport=5040\([0-9]\)\(.*\)$$/\1@172.16.239.1\3:21000?discport=0\&raftport=50400\4/g' > $${DDIR}/static-nodes.json
       cp $${DDIR}/static-nodes.json $${DDIR}/permissioned-nodes.json
       cat $${DDIR}/static-nodes.json
-      NETWORK_ID=$$(cat /config/istanbul-genesis.json | grep chainId | awk -F " " '{print $$2}' | awk -F "," '{print $$1}')
-      geth --datadir $${DDIR} init /config/istanbul-genesis.json
+      GENESIS_FILE="/examples/istanbul-genesis.json"
+      if [ "${QUORUM_CONSENSUS:-istanbul}" == "raft" ]; then
+        GENESIS_FILE="/examples/genesis.json"
+      fi
+      NETWORK_ID=$$(cat $${GENESIS_FILE} | grep chainId | awk -F " " '{print $$2}' | awk -F "," '{print $$1}')
+      GETH_ARGS_raft="--raft --raftport 50400"
+      GETH_ARGS_istanbul="--emitcheckpoints --istanbul.blockperiod 1 --mine --minerthreads 1 --syncmode full"
+      geth --datadir $${DDIR} init $${GENESIS_FILE}
       geth \
-        --identity node$${NODE_ID} \
+        --identity node$${NODE_ID}-${QUORUM_CONSENSUS:-istanbul} \
         --datadir $${DDIR} \
         --permissioned \
         --nodiscover \
         --verbosity 5 \
-        --networkid $$NETWORK_ID \
+        --networkid $${NETWORK_ID} \
         --rpc \
         --rpcaddr 0.0.0.0 \
         --rpcport 8545 \
-        --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul \
-        --emitcheckpoints \
+        --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,${QUORUM_CONSENSUS:-istanbul} \
         --port 21000 \
         --unlock 0 \
-        --password /config/passwords.txt \
-        --istanbul.blockperiod 1 \
-        --mine \
-        --minerthreads 1 \
-        --syncmode full
+        --password /examples/passwords.txt \
+        $${GETH_ARGS_${QUORUM_CONSENSUS:-istanbul}}
 x-tx-manager-tessera-def:
   &tx-manager-tessera-def
-  image: "${TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:latest}"
+  image: "${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:latest}"
   expose:
     - "9000"
   restart: "no"
+  healthcheck:
+    test: ["CMD", "wget", "--spider", "http://localhost:9000/upcheck"]
+    interval: 3s
+    timeout: 3s
+    retries: 10
+    start_period: 5s
   entrypoint:
     - /bin/sh
     - -c
@@ -57,8 +73,8 @@ x-tx-manager-tessera-def:
       DDIR=/qdata/tm
       rm -rf $${DDIR}
       mkdir -p $${DDIR}
-      cp /config/keys/tm$${NODE_ID}.pub $${DDIR}/tm.pub
-      cp /config/keys/tm$${NODE_ID}.key $${DDIR}/tm.key
+      cp /examples/keys/tm$${NODE_ID}.pub $${DDIR}/tm.pub
+      cp /examples/keys/tm$${NODE_ID}.key $${DDIR}/tm.key
       cat <<EOF > $${DDIR}/tessera-config.json
       {
           "useWhiteList": false,
@@ -126,10 +142,16 @@ x-tx-manager-tessera-def:
       java -Xms128M -Xmx128M -jar /tessera/tessera-app.jar -configfile $${DDIR}/tessera-config.json
 x-tx-manager-constellation-def:
   &tx-manager-constellation-def
-  image: "${TX_MANAGER_DOCKER_IMAGE:-quorumengineering/constellation:latest}"
+  image: "${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/constellation:latest}"
   expose:
     - "9000"
   restart: "no"
+  healthcheck:
+    test: ["CMD", "wget", "--spider", "http://localhost:9000"]
+    interval: 3s
+    timeout: 3s
+    retries: 10
+    start_period: 5s
   entrypoint:
     - /bin/sh
     - -c
@@ -137,14 +159,14 @@ x-tx-manager-constellation-def:
       DDIR=/qdata/tm
       rm -rf $${DDIR}
       mkdir -p $${DDIR}
-      echo "socket=\"$${DDIR}/tm.ipc\"\npublickeys=[\"/config/keys/tm$${NODE_ID}.pub\"]\n" > $${DDIR}/tm.conf
+      echo "socket=\"$${DDIR}/tm.ipc\"\npublickeys=[\"/examples/keys/tm$${NODE_ID}.pub\"]\n" > $${DDIR}/tm.conf
       constellation-node \
         --url=http://$$(hostname -i):9000/ \
         --port=9000 \
         --socket=$${DDIR}/tm.ipc \
         --othernodes=http://172.16.239.101:9000/,http://172.16.239.102:9000/,http://172.16.239.103:9000/,http://172.16.239.104:9000/,http://172.16.239.105:9000/ \
-        --publickeys=/config/keys/tm$${NODE_ID}.pub \
-        --privatekeys=/config/keys/tm$${NODE_ID}.key \
+        --publickeys=/examples/keys/tm$${NODE_ID}.pub \
+        --privatekeys=/examples/keys/tm$${NODE_ID}.key \
         --storage=$${DDIR} \
         --verbosity=4
 services:
@@ -152,10 +174,10 @@ services:
     << : *quorum-def
     hostname: node1
     ports:
-      - "22001:8545"
+      - "22000:8545"
     volumes:
       - 1:/qdata
-      - ./examples/7nodes:/config:ro
+      - ./examples/7nodes:/examples:ro
     depends_on:
       - txmanager1
     environment:
@@ -169,7 +191,7 @@ services:
     hostname: txmanager1
     volumes:
       - 1:/qdata
-      - ./examples/7nodes:/config:ro
+      - ./examples/7nodes:/examples:ro
     networks:
       quorum-examples-net:
         ipv4_address: 172.16.239.101
@@ -179,10 +201,10 @@ services:
     << : *quorum-def
     hostname: node2
     ports:
-      - "22002:8545"
+      - "22001:8545"
     volumes:
       - 2:/qdata
-      - ./examples/7nodes:/config:ro
+      - ./examples/7nodes:/examples:ro
     depends_on:
       - txmanager2
     environment:
@@ -196,7 +218,7 @@ services:
     hostname: txmanager2
     volumes:
       - 2:/qdata
-      - ./examples/7nodes:/config:ro
+      - ./examples/7nodes:/examples:ro
     networks:
       quorum-examples-net:
         ipv4_address: 172.16.239.102
@@ -206,10 +228,10 @@ services:
     << : *quorum-def
     hostname: node3
     ports:
-      - "22003:8545"
+      - "22002:8545"
     volumes:
       - 3:/qdata
-      - ./examples/7nodes:/config:ro
+      - ./examples/7nodes:/examples:ro
     depends_on:
       - txmanager3
     environment:
@@ -223,7 +245,7 @@ services:
     hostname: txmanager3
     volumes:
       - 3:/qdata
-      - ./examples/7nodes:/config:ro
+      - ./examples/7nodes:/examples:ro
     networks:
       quorum-examples-net:
         ipv4_address: 172.16.239.103
@@ -233,10 +255,10 @@ services:
     << : *quorum-def
     hostname: node4
     ports:
-      - "22004:8545"
+      - "22003:8545"
     volumes:
       - 4:/qdata
-      - ./examples/7nodes:/config:ro
+      - ./examples/7nodes:/examples:ro
     depends_on:
       - txmanager4
     environment:
@@ -250,7 +272,7 @@ services:
     hostname: txmanager4
     volumes:
       - 4:/qdata
-      - ./examples/7nodes:/config:ro
+      - ./examples/7nodes:/examples:ro
     networks:
       quorum-examples-net:
         ipv4_address: 172.16.239.104
@@ -260,10 +282,10 @@ services:
     << : *quorum-def
     hostname: node5
     ports:
-      - "22005:8545"
+      - "22004:8545"
     volumes:
       - 5:/qdata
-      - ./examples/7nodes:/config:ro
+      - ./examples/7nodes:/examples:ro
     depends_on:
       - txmanager5
     environment:
@@ -277,7 +299,7 @@ services:
     hostname: txmanager5
     volumes:
       - 5:/qdata
-      - ./examples/7nodes:/config:ro
+      - ./examples/7nodes:/examples:ro
     networks:
       quorum-examples-net:
         ipv4_address: 172.16.239.105
@@ -287,10 +309,10 @@ services:
     << : *quorum-def
     hostname: node6
     ports:
-      - "22006:8545"
+      - "22005:8545"
     volumes:
       - 6:/qdata
-      - ./examples/7nodes:/config:ro
+      - ./examples/7nodes:/examples:ro
     depends_on:
       - txmanager6
     environment:
@@ -304,7 +326,7 @@ services:
     hostname: txmanager6
     volumes:
       - 6:/qdata
-      - ./examples/7nodes:/config:ro
+      - ./examples/7nodes:/examples:ro
     networks:
       quorum-examples-net:
         ipv4_address: 172.16.239.106
@@ -314,10 +336,10 @@ services:
     << : *quorum-def
     hostname: node7
     ports:
-      - "22007:8545"
+      - "22006:8545"
     volumes:
       - 7:/qdata
-      - ./examples/7nodes:/config:ro
+      - ./examples/7nodes:/examples:ro
     depends_on:
       - txmanager7
     environment:
@@ -331,7 +353,7 @@ services:
     hostname: txmanager7
     volumes:
       - 7:/qdata
-      - ./examples/7nodes:/config:ro
+      - ./examples/7nodes:/examples:ro
     networks:
       quorum-examples-net:
         ipv4_address: 172.16.239.107


### PR DESCRIPTION
* Single Docker compose file to allow easy `docker-compose up` and `docker-compose down`
* Use official Quorum docker images
* Allow consensus algorithm and Docker images configuration via environment variables
* Default to use Istanbul BFT consensus and Tessera transaction manager