### PR TITLE
docker-compose: fixed keystore distribution

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # The following environment variables are substituted if present
 # * QUORUM_CONSENSUS: default to istanbul
 # * QUORUM_DOCKER_IMAGE: default to quorumengineering/quorum:latest
-# * QUORUM_QUORUM_TX_MANAGER_DOCKER_IMAGE: default to quorumengineering/tessera:latest
+# * QUORUM_TX_MANAGER_DOCKER_IMAGE: default to quorumengineering/tessera:latest
 version: "3.7"
 x-quorum-def:
   &quorum-def
@@ -27,7 +27,7 @@ x-quorum-def:
       mkdir -p $${DDIR}/keystore
       mkdir -p $${DDIR}/geth
       cp /examples/raft/nodekey$${NODE_ID} $${DDIR}/geth/nodekey
-      cp /examples/keys/key1 $${DDIR}/keystore/
+      cp /examples/keys/key$${NODE_ID} $${DDIR}/keystore/
       cat /examples/permissioned-nodes.json | sed 's/^\(.*\)@.*\?\(.*\)raftport=5040\([0-9]\)\(.*\)$$/\1@172.16.239.1\3:21000?discport=0\&raftport=50400\4/g' > $${DDIR}/static-nodes.json
       cp $${DDIR}/static-nodes.json $${DDIR}/permissioned-nodes.json
       cat $${DDIR}/static-nodes.json


### PR DESCRIPTION
there's a typo when copying the keystore to docker container causing all nodes using the same account