### PR TITLE
modify health check logic for tx manager

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,10 +61,10 @@ x-tx-manager-tessera-def:
     - "9000"
   restart: "no"
   healthcheck:
-    test: ["CMD", "wget", "--spider", "http://localhost:9000/upcheck"]
+    test: ["CMD-SHELL", "[ -S /qdata/tm/tm.ipc ] || exit 1"]
     interval: 3s
     timeout: 3s
-    retries: 10
+    retries: 20
     start_period: 5s
   entrypoint:
     - /bin/sh


### PR DESCRIPTION
Tessera no longer binds to localhost so the health check logic must change