### PR TITLE
Fixed Docker Composer file to run on Windows & fixed race condition for UDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ generate new ones using Geth's `account` tool and the `--generate-keys` option f
 ## Getting Started
 The 7nodes example can be run in three ways:
 1. By running a preconfigured Vagrant environment which comes complete with Quorum, Constellation, Tessera and the 7nodes example (__works on any machine__).
-1. By running [`docker-compose`](https://docs.docker.com/compose/) against a preconfigured [compose file](docker-compose.yml) which starts 7nodes example (__Windows is not supported__).
+1. By running [`docker-compose`](https://docs.docker.com/compose/) against a preconfigured [compose file](docker-compose.yml) which starts 7nodes example (tested on Windows 10, macOS Mojave & Ubuntu 18.04).
 1. By downloading and locally running Quorum, Tessera and the examples (__requires an Ubuntu-based/macOS machine; note that Constellation does not support running locally__)
 
 ### Setting up Vagrant

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ x-quorum-def:
       do
         set -e
         if [ -S $${PRIVATE_CONFIG} ] && \
-          [ "I'm up!" == "$$(wget -qO- 172.16.239.10$${NODE_ID}:9000/upcheck)" ];
+          [ "I'm up!" == "$$(wget --timeout $${UDS_WAIT} -qO- 172.16.239.10$${NODE_ID}:9000/upcheck)" ];
         then break
         else
           echo "Sleep $${UDS_WAIT} seconds. Waiting for TxManager."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ x-quorum-def:
       UDS_WAIT=10
       for i in $$(seq 1 100)
       do
-        if [ -S /qdata/tm/tm.ipc ];
+        if [ -S $${PRIVATE_CONFIG} ];
         then break
         else
         sleep $${UDS_WAIT}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,16 @@ x-quorum-def:
     - /bin/sh
     - -c
     - |
-      echo Sleep to avoid race conditon for unix domain socket
-      sleep 120
+      UDS_WAIT=10
+      for i in $$(seq 1 100)
+      do
+        if [ -S /qdata/tm/tm.ipc ];
+        then break
+        else
+        sleep $${UDS_WAIT}
+          echo "Sleep $${UDS_WAIT} seconds to avoid race conditon for unix domain socket"
+        fi
+      done
       DDIR=/qdata/dd
       rm -rf $${DDIR}
       mkdir -p $${DDIR}/keystore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,8 @@ x-quorum-def:
         if [ -S /qdata/tm/tm.ipc ];
         then break
         else
-        sleep $${UDS_WAIT}
           echo "Sleep $${UDS_WAIT} seconds to avoid race conditon for unix domain socket"
+          sleep $${UDS_WAIT}
         fi
       done
       DDIR=/qdata/dd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ x-quorum-def:
     - /bin/sh
     - -c
     - |
+      echo Sleep to avoid race conditon for unix domain socket
+      sleep 120
       DDIR=/qdata/dd
       rm -rf $${DDIR}
       mkdir -p $${DDIR}/keystore
@@ -173,7 +175,7 @@ services:
     ports:
       - "22000:8545"
     volumes:
-      - 1:/qdata
+      - vol1:/qdata
       - ./examples/7nodes:/examples:ro
     depends_on:
       - txmanager1
@@ -187,7 +189,7 @@ services:
     << : *tx-manager-def
     hostname: txmanager1
     volumes:
-      - 1:/qdata
+      - vol1:/qdata
       - ./examples/7nodes:/examples:ro
     networks:
       quorum-examples-net:
@@ -200,7 +202,7 @@ services:
     ports:
       - "22001:8545"
     volumes:
-      - 2:/qdata
+      - vol2:/qdata
       - ./examples/7nodes:/examples:ro
     depends_on:
       - txmanager2
@@ -214,7 +216,7 @@ services:
     << : *tx-manager-def
     hostname: txmanager2
     volumes:
-      - 2:/qdata
+      - vol2:/qdata
       - ./examples/7nodes:/examples:ro
     networks:
       quorum-examples-net:
@@ -227,7 +229,7 @@ services:
     ports:
       - "22002:8545"
     volumes:
-      - 3:/qdata
+      - vol3:/qdata
       - ./examples/7nodes:/examples:ro
     depends_on:
       - txmanager3
@@ -241,7 +243,7 @@ services:
     << : *tx-manager-def
     hostname: txmanager3
     volumes:
-      - 3:/qdata
+      - vol3:/qdata
       - ./examples/7nodes:/examples:ro
     networks:
       quorum-examples-net:
@@ -254,7 +256,7 @@ services:
     ports:
       - "22003:8545"
     volumes:
-      - 4:/qdata
+      - vol4:/qdata
       - ./examples/7nodes:/examples:ro
     depends_on:
       - txmanager4
@@ -268,7 +270,7 @@ services:
     << : *tx-manager-def
     hostname: txmanager4
     volumes:
-      - 4:/qdata
+      - vol4:/qdata
       - ./examples/7nodes:/examples:ro
     networks:
       quorum-examples-net:
@@ -281,7 +283,7 @@ services:
     ports:
       - "22004:8545"
     volumes:
-      - 5:/qdata
+      - vol5:/qdata
       - ./examples/7nodes:/examples:ro
     depends_on:
       - txmanager5
@@ -295,7 +297,7 @@ services:
     << : *tx-manager-def
     hostname: txmanager5
     volumes:
-      - 5:/qdata
+      - vol5:/qdata
       - ./examples/7nodes:/examples:ro
     networks:
       quorum-examples-net:
@@ -308,7 +310,7 @@ services:
     ports:
       - "22005:8545"
     volumes:
-      - 6:/qdata
+      - vol6:/qdata
       - ./examples/7nodes:/examples:ro
     depends_on:
       - txmanager6
@@ -322,7 +324,7 @@ services:
     << : *tx-manager-def
     hostname: txmanager6
     volumes:
-      - 6:/qdata
+      - vol6:/qdata
       - ./examples/7nodes:/examples:ro
     networks:
       quorum-examples-net:
@@ -335,7 +337,7 @@ services:
     ports:
       - "22006:8545"
     volumes:
-      - 7:/qdata
+      - vol7:/qdata
       - ./examples/7nodes:/examples:ro
     depends_on:
       - txmanager7
@@ -349,7 +351,7 @@ services:
     << : *tx-manager-def
     hostname: txmanager7
     volumes:
-      - 7:/qdata
+      - vol7:/qdata
       - ./examples/7nodes:/examples:ro
     networks:
       quorum-examples-net:
@@ -364,10 +366,10 @@ networks:
       config:
       - subnet: 172.16.239.0/24
 volumes:
-  "1":
-  "2":
-  "3":
-  "4":
-  "5":
-  "6":
-  "7":
+  "vol1":
+  "vol2":
+  "vol3":
+  "vol4":
+  "vol5":
+  "vol6":
+  "vol7":

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,10 +27,12 @@ x-quorum-def:
       UDS_WAIT=10
       for i in $$(seq 1 100)
       do
-        if [ -S $${PRIVATE_CONFIG} ];
+        set -e
+        if [ -S $${PRIVATE_CONFIG} ] && \
+          [ "I'm up!" == "$$(wget -qO- 172.16.239.10$${NODE_ID}:9000/upcheck)" ];
         then break
         else
-          echo "Sleep $${UDS_WAIT} seconds to avoid race conditon for unix domain socket"
+          echo "Sleep $${UDS_WAIT} seconds. Waiting for TxManager."
           sleep $${UDS_WAIT}
         fi
       done


### PR DESCRIPTION
I provided 2 fixes in this pull request:

* Explicitly name volumes with prefix `vol` so Docker containers for each pair of TxMgr and Geth can share the same volume on Windows. This allows Geth to access the Unix domain socket (UDS) `/qdata/tm/tm.ipc` properly
* Add dynamic & conditional sleep time to avoid race condition between the creator of the UDS `/qdata/tm/tm.ipc` (TxMgr) and the user of it (Geth node)

I have successfully tested on 3 environments:

* Windows 10
* macOS Mojave
* Ubuntu 18.04

Note that before this fix, all environments did see the race codition for `/qdata/tm/tm.ipc`. You can start `docker-compose up` without the flag `-d` to see it for yourself or check logs for each Geth node.