### PR TITLE
fixed tessera enhanced config condition

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,14 +99,10 @@ x-tx-manager-def:
           #extract the tessera version from the jar
           TESSERA_VERSION=$$(unzip -p /tessera/tessera-app.jar META-INF/MANIFEST.MF | grep Tessera-Version | cut -d" " -f2)
           echo "Tessera version (extracted from manifest file): $${TESSERA_VERSION}"
-          #we're going to do a lexicographic comparison further down so we need "0.8" to be bigger than "0.8 " - thus adding -suffix
-          TESSERA_VERSION="$${TESSERA_VERSION}-suffix"
-
+          # sorting versions to use enhanced config for >=0.8
+          export V=$$(echo -e "0.8\n$${TESSERA_VERSION}" | sort -n -r -t '.' -k 1,1 -k 2,2 | head -n1)
           TESSERA_CONFIG_TYPE=
-
-          #the space in "0.8 " is important in the lexicographic comparision (space is lower value than most printable chars)
-          #TODO - this will break when we get to version 0.10 (hopefully we would have moved to 1.x by then)
-          if [ "$${TESSERA_VERSION}" \> "0.8 " ]; then
+          if [ "$${V}" == "$${TESSERA_VERSION}" ]; then
               TESSERA_CONFIG_TYPE="-enhanced"
           fi
 


### PR DESCRIPTION
* Tessera >=0.8 supports raw transaction API with enhanced config
* Fixed version parsing in `docker-compose.yml`