### PR TITLE
Configure wget in Compose example to bypass Docker client proxy settings for healthchecks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ x-quorum-def:
     - "21000"
     - "50400"
   healthcheck:
-    test: ["CMD", "wget", "--spider", "http://localhost:8545"]
+    test: ["CMD", "wget", "--spider", "--proxy", "off", "http://localhost:8545"]
     interval: 3s
     timeout: 3s
     retries: 10
@@ -29,7 +29,7 @@ x-quorum-def:
       do
         set -e
         if [ -S $${PRIVATE_CONFIG} ] && \
-          [ "I'm up!" == "$$(wget --timeout $${UDS_WAIT} -qO- 172.16.239.10$${NODE_ID}:9000/upcheck)" ];
+          [ "I'm up!" == "$$(wget --timeout $${UDS_WAIT} -qO- --proxy off 172.16.239.10$${NODE_ID}:9000/upcheck)" ];
         then break
         else
           echo "Sleep $${UDS_WAIT} seconds. Waiting for TxManager."


### PR DESCRIPTION
In current version `docker-compose` example, `wget` uses Docker client proxy settings, when it tries to connect to another container. Obviously, usually external proxy will not be able to connect to Docker container running on your machine.
Furthermore, since example uses IPs at least in one `wget` call present in Compose config (and actually uses it for a range of IPs, not even a single one), you can't rely on `no_proxy` - by design it only respects domain names, not IP addresses or ranges.
`Localhost` wget call change might be an overkill, but if `no_proxy` isn't set, it still could fail, I guess.
It's a very simple change, but it fixed the problem for me and probably will fix the same issue, if others run into it.

 