### PR TITLE
Change tessera config generation to match changes in tessera

### DIFF
--- a/examples/7nodes/tessera-init.sh
+++ b/examples/7nodes/tessera-init.sh
@@ -92,30 +92,19 @@ EOF
         {
             "app":"ThirdParty",
             "enabled": true,
-            "serverSocket":{
-                "type":"INET",
-                "port": 908${i},
-                "hostName": "http://localhost"
-            },
+            "serverAddress": "http://localhost:908${i}",
             "communicationType" : "REST"
         },
         {
             "app":"Q2T",
             "enabled": true,
-            "serverSocket":{
-                "type":"UNIX",
-                "path":"${DDIR}/tm.ipc"
-            },
-            "communicationType" : "UNIX_SOCKET"
+             "serverAddress":"unix:${DDIR}/tm.ipc",
+            "communicationType" : "REST"
         },
         {
             "app":"P2P",
             "enabled": true,
-            "serverSocket":{
-                "type":"INET",
-                "port": 900${i},
-                "hostName": "http://localhost"
-            },
+            "serverAddress":"http://localhost:900${i}",
             "sslConfig": {
                 "tls": "OFF",
                 "generateKeyStoreIfNotExisted": true,

--- a/examples/7nodes/tessera-init.sh
+++ b/examples/7nodes/tessera-init.sh
@@ -92,6 +92,98 @@ EOF
         {
             "app":"ThirdParty",
             "enabled": true,
+            "serverSocket":{
+                "type":"INET",
+                "port": 908${i},
+                "hostName": "http://localhost"
+            },
+            "communicationType" : "REST"
+        },
+        {
+            "app":"Q2T",
+            "enabled": true,
+            "serverSocket":{
+                "type":"UNIX",
+                "path":"${DDIR}/tm.ipc"
+            },
+            "communicationType" : "UNIX_SOCKET"
+        },
+        {
+            "app":"P2P",
+            "enabled": true,
+            "serverSocket":{
+                "type":"INET",
+                "port": 900${i},
+                "hostName": "http://localhost"
+            },
+            "sslConfig": {
+                "tls": "OFF",
+                "generateKeyStoreIfNotExisted": true,
+                "serverKeyStore": "${DDIR}/server${i}-keystore",
+                "serverKeyStorePassword": "quorum",
+                "serverTrustStore": "${DDIR}/server-truststore",
+                "serverTrustStorePassword": "quorum",
+                "serverTrustMode": "TOFU",
+                "knownClientsFile": "${DDIR}/knownClients",
+                "clientKeyStore": "${DDIR}/client${i}-keystore",
+                "clientKeyStorePassword": "quorum",
+                "clientTrustStore": "${DDIR}/client-truststore",
+                "clientTrustStorePassword": "quorum",
+                "clientTrustMode": "TOFU",
+                "knownServersFile": "${DDIR}/knownServers"
+            },
+            "communicationType" : "REST"
+        }
+    ],
+    "peer": [
+        {
+            "url": "http://localhost:9001"
+        },
+        {
+            "url": "http://localhost:9002"
+        },
+        {
+            "url": "http://localhost:9003"
+        },
+        {
+            "url": "http://localhost:9004"
+        },
+        {
+            "url": "http://localhost:9005"
+        },
+        {
+            "url": "http://localhost:9006"
+        },
+        {
+            "url": "http://localhost:9007"
+        }
+    ],
+    "keys": {
+        "passwords": [],
+        "keyData": [
+            {
+                "privateKeyPath": "${DDIR}/tm.key",
+                "publicKeyPath": "${DDIR}/tm.pub"
+            }
+        ]
+    },
+    "alwaysSendTo": []
+}
+EOF
+
+cat <<EOF > ${DDIR}/tessera-config-09-${i}.json
+{
+    "useWhiteList": false,
+    "jdbc": {
+        "username": "sa",
+        "password": "",
+        "url": "jdbc:h2:${DDIR}/db${i};MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0",
+        "autoCreateTables": true
+    },
+    "serverConfigs":[
+        {
+            "app":"ThirdParty",
+            "enabled": true,
             "serverAddress": "http://localhost:908${i}",
             "communicationType" : "REST"
         },

--- a/examples/7nodes/tessera-start.sh
+++ b/examples/7nodes/tessera-start.sh
@@ -74,6 +74,10 @@ if [ "$TESSERA_VERSION" \> "0.8" ] || [ "$TESSERA_VERSION" == "0.8" ]; then
     TESSERA_CONFIG_TYPE="-enhanced-"
 fi
 
+if [ "$TESSERA_VERSION" \> "0.9" ] || [ "$TESSERA_VERSION" == "0.9" ]; then
+    TESSERA_CONFIG_TYPE="-09-"
+fi
+
 echo Config type $TESSERA_CONFIG_TYPE
 
 currentDir=`pwd`


### PR DESCRIPTION
Changes in this PR https://github.com/jpmorganchase/tessera/pull/653 included simplification of the tessera configuration. Server configurations now define a single uri whether the transport is unix domain socket or http uri.  