### PR TITLE
Set virtualbox ubuntu version when provisioning via vagrant.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,6 @@
 Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/xenial64"
+  config.vm.box_version = "20190325.0.0"
   config.vm.provision :shell, path: "vagrant/bootstrap.sh"
   config.vm.network "forwarded_port", guest: 22000, host: 22000
   config.vm.network "forwarded_port", guest: 22001, host: 22001


### PR DESCRIPTION
Errors were
1. `chown -R ubuntu:ubuntu`, instead of `vagrant:vagrant` which was causing
   an error.
2. put quorum-examples in the home directory which is `/home/ubuntu`
   instead of `/home/vagrant`.
3. fix wrong path to quorum from `/home/vagrant` to `/home/ubuntu`.

update README to indicate where the quorum-examples should be.
