### PR TITLE
Add remote enclave examples

### DIFF
--- a/examples/7nodes/README.md
+++ b/examples/7nodes/README.md
@@ -216,3 +216,12 @@ After making these changes, the `raft-init.sh` and `raft-start.sh` scripts can b
     </pre>
 
 After saving this change, the `./runscript.sh private-contract.js` command can be run as usual to submit the private contract.  You can then follow steps described above to verify that node 5 can see the transaction payload and that nodes 2-4 are unable to see the payload.
+
+## Using a Tessera remote enclave
+Tessera v0.9 brought with it the option to have an enclave as a separate process from the Transaction
+Manager. This is a more secure way of being able to manage and interact with your keys.
+To use the remote enclave, call your desired start with using `tessera-remote` as the first
+parameter, e.g. `./raft-start.sh tessera-remote`. This will, by default, start 7 Transaction
+Managers, the first 4 of which use a remote enclave. If you wish to change this number, you
+will need to add the extra parameter `--remoteEnclaves X` in the `--tesseraOptions`, e.g.
+`./raft-start.sh tessera-remote --tesseraOptions "--remoteEnclaves 7"`.

--- a/examples/7nodes/clique-start.sh
+++ b/examples/7nodes/clique-start.sh
@@ -5,17 +5,17 @@ set -e
 function usage() {
   echo ""
   echo "Usage:"
-  echo "    $0 [tessera | constellation] [--tesseraOptions \"options for Tessera start script\"]"
+  echo "    $0 [tessera | tessera-remote | constellation] [--tesseraOptions \"options for Tessera start script\"]"
   echo ""
   echo "Where:"
-  echo "    tessera | constellation (default = constellation): specifies which privacy implementation to use"
+  echo "    tessera | tessera-remote | constellation (default = tessera): specifies which privacy implementation to use"
   echo "    --tesseraOptions: allows additional options as documented in tessera-start.sh usage which is shown below:"
   echo ""
   ./tessera-start.sh --help
   exit -1
 }
 
-privacyImpl=constellation
+privacyImpl=tessera
 tesseraOptions=
 while (( "$#" )); do
     case "$1" in
@@ -25,6 +25,10 @@ while (( "$#" )); do
             ;;
         constellation)
             privacyImpl=constellation
+            shift
+            ;;
+        tessera-remote)
+            privacyImpl="tessera-remote"
             shift
             ;;
         --tesseraOptions)
@@ -59,6 +63,9 @@ if [ "$privacyImpl" == "tessera" ]; then
 elif [ "$privacyImpl" == "constellation" ]; then
   echo "[*] Starting Constellation nodes"
   ./constellation-start.sh
+elif [ "$privacyImpl" == "tessera-remote" ]; then
+  echo "[*] Starting tessera nodes"
+  ./tessera-start-remote.sh ${tesseraOptions}
 else
   echo "Unsupported privacy implementation: ${privacyImpl}"
   usage

--- a/examples/7nodes/istanbul-start.sh
+++ b/examples/7nodes/istanbul-start.sh
@@ -5,17 +5,17 @@ set -e
 function usage() {
   echo ""
   echo "Usage:"
-  echo "    $0 [tessera | constellation] [--tesseraOptions \"options for Tessera start script\"]"
+  echo "    $0 [tessera | tessera-remote | constellation] [--tesseraOptions \"options for Tessera start script\"]"
   echo ""
   echo "Where:"
-  echo "    tessera | constellation (default = constellation): specifies which privacy implementation to use"
+  echo "    tessera | tessera-remote | constellation (default = tessera): specifies which privacy implementation to use"
   echo "    --tesseraOptions: allows additional options as documented in tessera-start.sh usage which is shown below:"
   echo ""
   ./tessera-start.sh --help
   exit -1
 }
 
-privacyImpl=constellation
+privacyImpl=tessera
 tesseraOptions=
 while (( "$#" )); do
     case "$1" in
@@ -25,6 +25,10 @@ while (( "$#" )); do
             ;;
         constellation)
             privacyImpl=constellation
+            shift
+            ;;
+        tessera-remote)
+            privacyImpl="tessera-remote"
             shift
             ;;
         --tesseraOptions)
@@ -59,6 +63,9 @@ if [ "$privacyImpl" == "tessera" ]; then
 elif [ "$privacyImpl" == "constellation" ]; then
   echo "[*] Starting Constellation nodes"
   ./constellation-start.sh
+elif [ "$privacyImpl" == "tessera-remote" ]; then
+  echo "[*] Starting tessera nodes"
+  ./tessera-start-remote.sh ${tesseraOptions}
 else
   echo "Unsupported privacy implementation: ${privacyImpl}"
   usage

--- a/examples/7nodes/raft-start.sh
+++ b/examples/7nodes/raft-start.sh
@@ -5,17 +5,17 @@ set -e
 function usage() {
   echo ""
   echo "Usage:"
-  echo "    $0 [tessera | constellation] [--tesseraOptions \"options for Tessera start script\"]"
+  echo "    $0 [tessera | tessera-remote | constellation] [--tesseraOptions \"options for Tessera start script\"]"
   echo ""
   echo "Where:"
-  echo "    tessera | constellation (default = constellation): specifies which privacy implementation to use"
+  echo "    tessera | tessera-remote | constellation (default = tessera): specifies which privacy implementation to use"
   echo "    --tesseraOptions: allows additional options as documented in tessera-start.sh usage which is shown below:"
   echo ""
   ./tessera-start.sh --help
   exit -1
 }
 
-privacyImpl=constellation
+privacyImpl=tessera
 tesseraOptions=
 while (( "$#" )); do
     case "$1" in
@@ -25,6 +25,10 @@ while (( "$#" )); do
             ;;
         constellation)
             privacyImpl=constellation
+            shift
+            ;;
+        tessera-remote)
+            privacyImpl="tessera-remote"
             shift
             ;;
         --tesseraOptions)
@@ -59,6 +63,9 @@ if [ "$privacyImpl" == "tessera" ]; then
 elif [ "$privacyImpl" == "constellation" ]; then
   echo "[*] Starting Constellation nodes"
   ./constellation-start.sh
+elif [ "$privacyImpl" == "tessera-remote" ]; then
+  echo "[*] Starting tessera nodes"
+  ./tessera-start-remote.sh ${tesseraOptions}
 else
   echo "Unsupported privacy implementation: ${privacyImpl}"
   usage

--- a/examples/7nodes/stop.sh
+++ b/examples/7nodes/stop.sh
@@ -1,9 +1,17 @@
 #!/bin/bash
-killall geth bootnode constellation-node
+killall -INT geth
+killall bootnode constellation-node
 
 if [ "`jps | grep tessera`" != "" ]
 then
-  jps | grep tessera | cut -d " " -f1 | xargs kill
+    jps | grep tessera | cut -d " " -f1 | xargs kill
 else
-  echo "tessera: no process found"
+    echo "tessera: no process found"
+fi
+
+if [ "`jps | grep enclave`" != "" ]
+then
+    jps | grep enclave | cut -d " " -f1 | xargs kill
+else
+    echo "enclave: no process found"
 fi

--- a/examples/7nodes/tessera-init.sh
+++ b/examples/7nodes/tessera-init.sh
@@ -13,164 +13,6 @@ do
     rm -f "${DDIR}/tm.ipc"
 
     #change tls to "strict" to enable it (don't forget to also change http -> https)
-    cat <<EOF > ${DDIR}/tessera-config${i}.json
-{
-    "useWhiteList": false,
-    "jdbc": {
-        "username": "sa",
-        "password": "",
-        "url": "jdbc:h2:${DDIR}/db${i};MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0",
-        "autoCreateTables": true
-    },
-    "server": {
-        "port": 900${i},
-        "hostName": "http://localhost",
-        "sslConfig": {
-            "tls": "OFF",
-            "generateKeyStoreIfNotExisted": true,
-            "serverKeyStore": "${DDIR}/server${i}-keystore",
-            "serverKeyStorePassword": "quorum",
-            "serverTrustStore": "${DDIR}/server-truststore",
-            "serverTrustStorePassword": "quorum",
-            "serverTrustMode": "TOFU",
-            "knownClientsFile": "${DDIR}/knownClients",
-            "clientKeyStore": "${DDIR}/client${i}-keystore",
-            "clientKeyStorePassword": "quorum",
-            "clientTrustStore": "${DDIR}/client-truststore",
-            "clientTrustStorePassword": "quorum",
-            "clientTrustMode": "TOFU",
-            "knownServersFile": "${DDIR}/knownServers"
-        }
-    },
-    "peer": [
-        {
-            "url": "http://localhost:9001"
-        },
-        {
-            "url": "http://localhost:9002"
-        },
-        {
-            "url": "http://localhost:9003"
-        },
-        {
-            "url": "http://localhost:9004"
-        },
-        {
-            "url": "http://localhost:9005"
-        },
-        {
-            "url": "http://localhost:9006"
-        },
-        {
-            "url": "http://localhost:9007"
-        }
-    ],
-    "keys": {
-        "passwords": [],
-        "keyData": [
-            {
-                "privateKeyPath": "${DDIR}/tm.key",
-                "publicKeyPath": "${DDIR}/tm.pub"
-            }
-        ]
-    },
-    "alwaysSendTo": [],
-    "unixSocketFile": "${DDIR}/tm.ipc"
-}
-EOF
-
-    cat <<EOF > ${DDIR}/tessera-config-enhanced-${i}.json
-{
-    "useWhiteList": false,
-    "jdbc": {
-        "username": "sa",
-        "password": "",
-        "url": "jdbc:h2:${DDIR}/db${i};MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0",
-        "autoCreateTables": true
-    },
-    "serverConfigs":[
-        {
-            "app":"ThirdParty",
-            "enabled": true,
-            "serverSocket":{
-                "type":"INET",
-                "port": 908${i},
-                "hostName": "http://localhost"
-            },
-            "communicationType" : "REST"
-        },
-        {
-            "app":"Q2T",
-            "enabled": true,
-            "serverSocket":{
-                "type":"UNIX",
-                "path":"${DDIR}/tm.ipc"
-            },
-            "communicationType" : "UNIX_SOCKET"
-        },
-        {
-            "app":"P2P",
-            "enabled": true,
-            "serverSocket":{
-                "type":"INET",
-                "port": 900${i},
-                "hostName": "http://localhost"
-            },
-            "sslConfig": {
-                "tls": "OFF",
-                "generateKeyStoreIfNotExisted": true,
-                "serverKeyStore": "${DDIR}/server${i}-keystore",
-                "serverKeyStorePassword": "quorum",
-                "serverTrustStore": "${DDIR}/server-truststore",
-                "serverTrustStorePassword": "quorum",
-                "serverTrustMode": "TOFU",
-                "knownClientsFile": "${DDIR}/knownClients",
-                "clientKeyStore": "${DDIR}/client${i}-keystore",
-                "clientKeyStorePassword": "quorum",
-                "clientTrustStore": "${DDIR}/client-truststore",
-                "clientTrustStorePassword": "quorum",
-                "clientTrustMode": "TOFU",
-                "knownServersFile": "${DDIR}/knownServers"
-            },
-            "communicationType" : "REST"
-        }
-    ],
-    "peer": [
-        {
-            "url": "http://localhost:9001"
-        },
-        {
-            "url": "http://localhost:9002"
-        },
-        {
-            "url": "http://localhost:9003"
-        },
-        {
-            "url": "http://localhost:9004"
-        },
-        {
-            "url": "http://localhost:9005"
-        },
-        {
-            "url": "http://localhost:9006"
-        },
-        {
-            "url": "http://localhost:9007"
-        }
-    ],
-    "keys": {
-        "passwords": [],
-        "keyData": [
-            {
-                "privateKeyPath": "${DDIR}/tm.key",
-                "publicKeyPath": "${DDIR}/tm.pub"
-            }
-        ]
-    },
-    "alwaysSendTo": []
-}
-EOF
-
 cat <<EOF > ${DDIR}/tessera-config-09-${i}.json
 {
     "useWhiteList": false,
@@ -237,6 +79,95 @@ cat <<EOF > ${DDIR}/tessera-config-09-${i}.json
         },
         {
             "url": "http://localhost:9007"
+        }
+    ],
+    "keys": {
+        "passwords": [],
+        "keyData": [
+            {
+                "privateKeyPath": "${DDIR}/tm.key",
+                "publicKeyPath": "${DDIR}/tm.pub"
+            }
+        ]
+    },
+    "alwaysSendTo": []
+}
+EOF
+
+# Enclave configurations
+
+cat <<EOF > ${DDIR}/tessera-config-enclave-09-${i}.json
+{
+    "useWhiteList": false,
+    "jdbc": {
+        "username": "sa",
+        "password": "",
+        "url": "jdbc:h2:${DDIR}/db${i};MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0",
+        "autoCreateTables": true
+    },
+    "serverConfigs":[
+        {
+            "app":"ENCLAVE",
+            "enabled": true,
+            "serverAddress": "http://localhost:918${i}",
+            "communicationType" : "REST"
+        },
+        {
+            "app":"ThirdParty",
+            "enabled": true,
+            "serverAddress": "http://localhost:908${i}",
+            "communicationType" : "REST"
+        },
+        {
+            "app":"Q2T",
+            "enabled": true,
+             "serverAddress":"unix:${DDIR}/tm.ipc",
+            "communicationType" : "REST"
+        },
+        {
+            "app":"P2P",
+            "enabled": true,
+            "serverAddress":"http://localhost:900${i}",
+            "sslConfig": {
+                "tls": "OFF"
+            },
+            "communicationType" : "REST"
+        }
+    ],
+    "peer": [
+        {
+            "url": "http://localhost:9001"
+        },
+        {
+            "url": "http://localhost:9002"
+        },
+        {
+            "url": "http://localhost:9003"
+        },
+        {
+            "url": "http://localhost:9004"
+        },
+        {
+            "url": "http://localhost:9005"
+        },
+        {
+            "url": "http://localhost:9006"
+        },
+        {
+            "url": "http://localhost:9007"
+        }
+    ]
+}
+EOF
+
+cat <<EOF > ${DDIR}/enclave-09-${i}.json
+{
+    "serverConfigs":[
+        {
+            "app":"ENCLAVE",
+            "enabled": true,
+            "serverAddress": "http://localhost:918${i}",
+            "communicationType" : "REST"
         }
     ],
     "keys": {

--- a/examples/7nodes/tessera-start-remote.sh
+++ b/examples/7nodes/tessera-start-remote.sh
@@ -1,0 +1,258 @@
+#!/bin/bash
+set -u
+set -e
+
+function usage() {
+  echo ""
+  echo "Usage:"
+  echo "    $0 [--tesseraJar path to Tessera jar file] [--remoteDebug] [--jvmParams \"JVM parameters\"] [--remoteEnclaves <number of remote enclaves>]"
+  echo ""
+  echo "Where:"
+  echo "    --tesseraJar specifies path to the jar file, default is to use the vagrant location"
+  echo "    --remoteDebug enables remote debug on port 500n for each Tessera node (for use with JVisualVm etc)"
+  echo "    --jvmParams specifies parameters to be used by JVM when running Tessera"
+  echo "    --remoteEnclaves specifies the number of nodes that should be using a remote enclave"
+  echo "Notes:"
+  echo "    Tessera jar location defaults to ${defaultTesseraJarExpr};"
+  echo "    Enclave jar location defaults to ${defaultEnclaveJarExpr};"
+  echo "    however, this can be overridden by environment variable TESSERA_JAR or ENCLAVE_JAR or by the command line option."
+  echo ""
+  exit -1
+}
+
+defaultNumberOfRemoteEnclaves=4
+defaultEnclaveJarExpr="/home/vagrant/tessera/enclave.jar"
+defaultTesseraJarExpr="/home/vagrant/tessera/tessera.jar"
+
+set +e
+defaultTesseraJar=`find ${defaultTesseraJarExpr} 2>/dev/null`
+set -e
+if [[ "${TESSERA_JAR:-unset}" == "unset" ]]; then
+  tesseraJar=${defaultTesseraJar}
+else
+  tesseraJar=${TESSERA_JAR}
+fi
+
+set +e
+defaultEnclaveJar=`find ${defaultEnclaveJarExpr} 2>/dev/null`
+set -e
+if [[ "${ENCLAVE_JAR:-unset}" == "unset" ]]; then
+  enclaveJar=${defaultEnclaveJar}
+else
+  enclaveJar=${ENCLAVE_JAR}
+fi
+
+numberOfRemoteEnclaves=${defaultNumberOfRemoteEnclaves}
+
+remoteDebug=false
+jvmParams=
+while (( "$#" )); do
+  case "$1" in
+    --tesseraJar)
+      tesseraJar=$2
+      shift 2
+      ;;
+    --remoteEnclaves)
+      numberOfRemoteEnclaves=$2
+      shift 2
+      ;;
+    --enclaveJar)
+      enclaveJar=$2
+      shift 2
+      ;;
+    --remoteDebug)
+      remoteDebug=true
+      shift
+      ;;
+    --jvmParams)
+      jvmParams=$2
+      shift 2
+      ;;
+    --help)
+      shift
+      usage
+      ;;
+    *)
+      echo "Error: Unsupported command line parameter $1"
+      usage
+      ;;
+  esac
+done
+
+if [  "${tesseraJar}" == "" ]; then
+  echo "ERROR: unable to find Tessera jar file using TESSERA_JAR envvar, or using ${defaultTesseraJarExpr}"
+  usage
+elif [  ! -f "${tesseraJar}" ]; then
+  echo "ERROR: unable to find Tessera jar file: ${tesseraJar}"
+  usage
+fi
+
+if [  "${enclaveJar}" == "" ]; then
+  echo "ERROR: unable to find Enclave jar file using ENCLAVE_JAR envvar, or using ${defaultEnclaveJarExpr}"
+  usage
+elif [  ! -f "${enclaveJar}" ]; then
+  echo "ERROR: unable to find Enclave jar file: ${enclaveJar}"
+  usage
+fi
+
+#extract the tessera version from the jar
+TESSERA_VERSION=$(unzip -p $tesseraJar META-INF/MANIFEST.MF | grep Tessera-Version | cut -d" " -f2)
+echo "Tessera version (extracted from manifest file): $TESSERA_VERSION"
+
+TESSERA_CONFIG_TYPE="-09-"
+
+#if the Tessera version is 0.10, use this config version
+if [ "$TESSERA_VERSION" \> "0.10" ] || [ "$TESSERA_VERSION" == "0.10" ]; then
+    TESSERA_CONFIG_TYPE="-09-"
+fi
+
+echo "Config type $TESSERA_CONFIG_TYPE"
+
+
+# Order of operation:
+# Start up the remote enclaves
+# Wait for remote enclaves to finish startup
+# Start up remote enclave enabled transaction managers
+# Start up local enclave transaction managers
+# Wait for all transaction managers to finish startup
+
+#Start up all remote enclaves (from node 1 to numberOfRemoteEnclaves)
+for ((i=1;i<=numberOfRemoteEnclaves;i++));
+do
+    DDIR="qdata/c$i"
+    mkdir -p ${DDIR}
+    mkdir -p qdata/logs
+    rm -f "$DDIR/tm.ipc"
+
+    DEBUG=""
+    if [ "$remoteDebug" == "true" ]; then
+      DEBUG="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=501$i -Xdebug"
+    fi
+
+    #Only set heap size if not specified on command line
+    MEMORY=
+    if [[ ! "$jvmParams" =~ "Xm" ]]; then
+      MEMORY="-Xms128M -Xmx128M"
+    fi
+
+    CMD="java $jvmParams $DEBUG $MEMORY -jar ${enclaveJar} -configfile $DDIR/enclave$TESSERA_CONFIG_TYPE$i.json"
+    echo "$CMD >> qdata/logs/enclave$i.log 2>&1 &"
+    ${CMD} >> "qdata/logs/enclave$i.log" 2>&1 &
+    sleep 1
+done
+
+#Wait until all Enclaves are running
+echo "Waiting until all Tessera enclaves are running..."
+DOWN=true
+k=10
+while ${DOWN}; do
+    sleep 1
+    DOWN=false
+    for ((i=1;i<=numberOfRemoteEnclaves;i++));
+    do
+        set +e
+
+        result=$(curl -s http://localhost:918${i}/ping)
+        set -e
+        if [ ! "${result}" == "STARTED" ]; then
+            echo "Enclave ${i} is not yet listening on http"
+            DOWN=true
+        fi
+    done
+
+    k=$((k - 1))
+    if [ ${k} -le 0 ]; then
+        echo "Tessera is taking a long time to start.  Look at the Tessera logs in qdata/logs/ for help diagnosing the problem."
+    fi
+    echo "Waiting until all Tessera enclaves are running..."
+
+    sleep 5
+done
+
+#Startup all remote enclave Transaction Managers (from nodes 1 to numberOfRemoteEnclaves)
+currentDir=`pwd`
+for ((i=1;i<=numberOfRemoteEnclaves;i++));
+do
+    DDIR="qdata/c$i"
+    mkdir -p ${DDIR}
+    mkdir -p qdata/logs
+    rm -f "$DDIR/tm.ipc"
+
+    DEBUG=""
+    if [ "$remoteDebug" == "true" ]; then
+      DEBUG="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=500$i -Xdebug"
+    fi
+
+    #Only set heap size if not specified on command line
+    MEMORY=
+    if [[ ! "$jvmParams" =~ "Xm" ]]; then
+      MEMORY="-Xms128M -Xmx128M"
+    fi
+
+    CMD="java $jvmParams $DEBUG $MEMORY -jar ${tesseraJar} -configfile $DDIR/tessera-config-enclave$TESSERA_CONFIG_TYPE$i.json"
+    echo "$CMD >> qdata/logs/tessera$i.log 2>&1 &"
+    ${CMD} >> "qdata/logs/tessera$i.log" 2>&1 &
+    sleep 1
+done
+
+#Startup all local enclave Transaction Managers (from nodes numberOfRemoteEnclaves+1 to 7)
+for ((i=numberOfRemoteEnclaves+1;i<=7;i++));
+do
+    DDIR="qdata/c$i"
+    mkdir -p ${DDIR}
+    mkdir -p qdata/logs
+    rm -f "$DDIR/tm.ipc"
+
+    DEBUG=""
+    if [ "$remoteDebug" == "true" ]; then
+      DEBUG="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=500$i -Xdebug"
+    fi
+
+    #Only set heap size if not specified on command line
+    MEMORY=
+    if [[ ! "$jvmParams" =~ "Xm" ]]; then
+      MEMORY="-Xms128M -Xmx128M"
+    fi
+
+    CMD="java $jvmParams $DEBUG $MEMORY -jar ${tesseraJar} -configfile $DDIR/tessera-config$TESSERA_CONFIG_TYPE$i.json"
+    echo "$CMD >> qdata/logs/tessera$i.log 2>&1 &"
+    ${CMD} >> "qdata/logs/tessera$i.log" 2>&1 &
+    sleep 1
+done
+
+#Wait until all 7 transaction managers are running
+echo "Waiting until all Tessera nodes are running..."
+DOWN=true
+k=10
+while ${DOWN}; do
+    sleep 1
+    DOWN=false
+    for ((i=1;i<=7;i++));
+    do
+        if [ ! -S "qdata/c${i}/tm.ipc" ]; then
+            echo "Node ${i} is not yet listening on tm.ipc"
+            DOWN=true
+        fi
+
+        set +e
+        #NOTE: if using https, change the scheme
+        #NOTE: if using the IP whitelist, change the host to an allowed host
+        result=$(curl -s http://localhost:900${i}/upcheck)
+        set -e
+        if [ ! "${result}" == "I'm up!" ]; then
+            echo "Node ${i} is not yet listening on http"
+            DOWN=true
+        fi
+    done
+
+    k=$((k - 1))
+    if [ ${k} -le 0 ]; then
+        echo "Tessera is taking a long time to start.  Look at the Tessera logs in qdata/logs/ for help diagnosing the problem."
+    fi
+    echo "Waiting until all Tessera nodes are running..."
+
+    sleep 5
+done
+
+echo "All Tessera nodes started"
+exit 0

--- a/examples/7nodes/tessera-start.sh
+++ b/examples/7nodes/tessera-start.sh
@@ -67,17 +67,9 @@ fi
 TESSERA_VERSION=$(unzip -p $tesseraJar META-INF/MANIFEST.MF | grep Tessera-Version | cut -d" " -f2)
 echo "Tessera version (extracted from manifest file): $TESSERA_VERSION"
 
-TESSERA_CONFIG_TYPE=
+TESSERA_CONFIG_TYPE="-09-"
 
-#TODO - this will break when we get to version 0.10 (hopefully we would have moved to 1.x by then)
-if [ "$TESSERA_VERSION" \> "0.8" ] || [ "$TESSERA_VERSION" == "0.8" ]; then
-    TESSERA_CONFIG_TYPE="-enhanced-"
-fi
-
-if [ "$TESSERA_VERSION" \> "0.9" ] || [ "$TESSERA_VERSION" == "0.9" ]; then
-    TESSERA_CONFIG_TYPE="-09-"
-fi
-
+#if the Tessera version is 0.10, use this config version
 if [ "$TESSERA_VERSION" \> "0.10" ] || [ "$TESSERA_VERSION" == "0.10" ]; then
     TESSERA_CONFIG_TYPE="-09-"
 fi

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -10,21 +10,23 @@ apt-get install -y build-essential unzip libdb-dev libleveldb-dev libsodium-dev 
 CVER="0.3.2"
 CREL="constellation-$CVER-ubuntu1604"
 wget -q https://github.com/jpmorganchase/constellation/releases/download/v$CVER/$CREL.tar.xz
-tar xfJ $CREL.tar.xz
-cp $CREL/constellation-node /usr/local/bin && chmod 0755 /usr/local/bin/constellation-node
-rm -rf $CREL
+tar xfJ ${CREL}.tar.xz
+cp ${CREL}/constellation-node /usr/local/bin && chmod 0755 /usr/local/bin/constellation-node
+rm -rf ${CREL}
 
 # install tessera
 mkdir -p /home/vagrant/tessera
 wget -O /home/vagrant/tessera/tessera.jar -q https://oss.sonatype.org/content/groups/public/com/jpmorgan/quorum/tessera-app/0.9/tessera-app-0.9-app.jar
+wget -O /home/vagrant/tessera/enclave.jar -q https://oss.sonatype.org/content/groups/public/com/jpmorgan/quorum/enclave-jaxrs/0.9/enclave-jaxrs-0.9-server.jar
 echo "TESSERA_JAR=/home/vagrant/tessera/tessera.jar" >> /home/vagrant/.profile
+echo "ENCLAVE_JAR=/home/vagrant/tessera/enclave.jar" >> /home/vagrant/.profile
 
 # install golang
 GOREL=go1.9.3.linux-amd64.tar.gz
-wget -q https://dl.google.com/go/$GOREL
-tar xfz $GOREL
+wget -q https://dl.google.com/go/${GOREL}
+tar xfz ${GOREL}
 mv go /usr/local/go
-rm -f $GOREL
+rm -f ${GOREL}
 PATH=$PATH:/usr/local/go/bin
 echo 'PATH=$PATH:/usr/local/go/bin' >> /home/vagrant/.bashrc
 


### PR DESCRIPTION
This updates the `Vagrantfile` and `docker-compose` file to use Tessera v0.9.

It also contains 7node examples of using Tessera with a remote enclave - one with all 7 nodes using an enclave and another which defaults to 4, but can be changed for any number from 1 to 7.