### PR TITLE
enable constantinople

### DIFF
--- a/examples/7nodes/clique-genesis.json
+++ b/examples/7nodes/clique-genesis.json
@@ -20,6 +20,7 @@
   "config": {
     "homesteadBlock": 0,
     "byzantiumBlock": 0,
+    "constantinopleBlock":0,
     "chainId": 10,
     "eip150Block": 0,
     "eip155Block": 0,

--- a/examples/7nodes/genesis.json
+++ b/examples/7nodes/genesis.json
@@ -20,6 +20,7 @@
   "config": {
     "homesteadBlock": 0,
     "byzantiumBlock": 0,
+    "constantinopleBlock":0,
     "chainId": 10,
     "eip150Block": 0,
     "eip155Block": 0,

--- a/examples/7nodes/istanbul-genesis.json
+++ b/examples/7nodes/istanbul-genesis.json
@@ -20,6 +20,7 @@
     "config": {
       "homesteadBlock": 0,
       "byzantiumBlock": 0,
+      "constantinopleBlock":0,
       "chainId": 10,
       "eip150Block": 0,
       "eip150Hash": "0x0000000000000000000000000000000000000000000000000000000000000000",


### PR DESCRIPTION
Creating this PR to enable Constantinople so that the 7 node example will support solc 0.5.5+ default.