### PR TITLE
Add name to network configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -407,6 +407,7 @@ services:
       - NODE_ID=7
 networks:
   quorum-examples-net:
+    name: quorum-examples-net
     driver: bridge
     ipam:
       driver: default


### PR DESCRIPTION
This will make it easier to interact with from other docker-compose files. docker-compose adds your current directory as a prefix to the network name.