### PR TITLE
download geth instead of build from source

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # The following environment variables are substituted if present
 # * QUORUM_CONSENSUS: default to istanbul
-# * QUORUM_DOCKER_IMAGE: default to quorumengineering/quorum:2.2.4
-# * QUORUM_TX_MANAGER_DOCKER_IMAGE: default to quorumengineering/tessera:0.9.2
+# * QUORUM_DOCKER_IMAGE: default to quorumengineering/quorum:2.2.5
+# * QUORUM_TX_MANAGER_DOCKER_IMAGE: default to quorumengineering/tessera:0.10.0
 # * QUORUM_GETH_ARGS: extra geth arguments to be included when running geth
 # To use Constellation, set QUORUM_TX_MANAGER_DOCKER_IMAGE to Constellation docker image,
 # e.g.: QUORUM_TX_MANAGER_DOCKER_IMAGE=quorumengineering/constellation:0.3.2 docker-compose up -d
@@ -10,7 +10,7 @@ version: "3.6"
 x-quorum-def:
   &quorum-def
   restart: "on-failure"
-  image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:2.2.4}"
+  image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:2.2.5}"
   expose:
     - "21000"
     - "50400"
@@ -72,7 +72,7 @@ x-quorum-def:
         ${QUORUM_GETH_ARGS:-} $${GETH_ARGS_${QUORUM_CONSENSUS:-istanbul}}
 x-tx-manager-def:
   &tx-manager-def
-  image: "${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:0.9.2}"
+  image: "${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:0.10.0}"
   expose:
     - "9000"
     - "9080"
@@ -90,7 +90,7 @@ x-tx-manager-def:
       DDIR=/qdata/tm
       rm -rf $${DDIR}
       mkdir -p $${DDIR}
-      DOCKER_IMAGE="${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:0.9.2}"
+      DOCKER_IMAGE="${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:0.10.0}"
       TX_MANAGER=$$(echo $${DOCKER_IMAGE} | sed 's/^.*\/\(.*\):.*$$/\1/g')
       echo "TxManager: $${TX_MANAGER}"
       case $${TX_MANAGER}

--- a/examples/7nodes/stop.sh
+++ b/examples/7nodes/stop.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 killall -INT geth
-killall bootnode constellation-node
+killall constellation-node
 
 if [ "`jps | grep tessera`" != "" ]
 then


### PR DESCRIPTION
* download `geth` binary directly from bintray instead of build from source
* parallel downloading all binaries
* remove unnecessary dependencies
* update binaries to latest versions

Before: vagrant up  5.55s user 2.21s system 2% cpu 5:05.73 total
After: vagrant up  4.45s user 1.85s system 7% cpu 1:20.97 total