### PR TITLE
Adding options to istanbul scripts to support istanbul-tools and varying number of nodes

### DIFF
--- a/examples/7nodes/clique-init.sh
+++ b/examples/7nodes/clique-init.sh
@@ -2,65 +2,63 @@
 set -u
 set -e
 
+function usage() {
+  echo ""
+  echo "Usage:"
+  echo "    $0 [--numNodes numberOfNodes]"
+  echo ""
+  echo "Where:"
+  echo "    numberOfNodes is the number of nodes to initialise (default = $numNodes)"
+  echo ""
+  exit -1
+}
+
+numNodes=7
+while (( "$#" )); do
+    case "$1" in
+        --numNodes)
+            re='^[0-9]+$'
+            if ! [[ $2 =~ $re ]] ; then
+                echo "ERROR: numberOfNodes value must be a number"
+                usage
+            fi
+            numNodes=$2
+            shift 2
+            ;;
+        --help)
+            shift
+            usage
+            ;;
+        *)
+            echo "Error: Unsupported command line parameter $1"
+            usage
+            ;;
+    esac
+done
+
 echo "[*] Cleaning up temporary data directories"
 rm -rf qdata
 mkdir -p qdata/logs
 
-echo "[*] Configuring node 1"
-mkdir -p qdata/dd1/{keystore,geth}
-cp permissioned-nodes.json qdata/dd1/static-nodes.json
-cp permissioned-nodes.json qdata/dd1/
-cp keys/key1 qdata/dd1/keystore
-cp raft/nodekey1 qdata/dd1/geth/nodekey
-geth --datadir qdata/dd1 init clique-genesis.json
+echo "[*] Configuring for $numNodes node(s)"
+echo $numNodes > qdata/numberOfNodes
 
-echo "[*] Configuring node 2"
-mkdir -p qdata/dd2/{keystore,geth}
-cp permissioned-nodes.json qdata/dd2/static-nodes.json
-cp permissioned-nodes.json qdata/dd2/
-cp keys/key2 qdata/dd2/keystore
-cp raft/nodekey2 qdata/dd2/geth/nodekey
-geth --datadir qdata/dd2 init clique-genesis.json
+numPermissionedNodes=`grep "enode" permissioned-nodes.json |wc -l`
+if [[ $numPermissionedNodes -ne $numNodes ]]; then
+    echo "ERROR: $numPermissionedNodes nodes are configured in 'permissioned-nodes.json', but expecting configuration for $numNodes nodes"
+    exit -1
+fi
 
-echo "[*] Configuring node 3"
-mkdir -p qdata/dd3/{keystore,geth}
-cp permissioned-nodes.json qdata/dd3/static-nodes.json
-cp permissioned-nodes.json qdata/dd3/
-cp keys/key3 qdata/dd3/keystore
-cp raft/nodekey3 qdata/dd3/geth/nodekey
-geth --datadir qdata/dd3 init clique-genesis.json
-
-echo "[*] Configuring node 4 as voter"
-mkdir -p qdata/dd4/{keystore,geth}
-cp permissioned-nodes.json qdata/dd4/static-nodes.json
-cp permissioned-nodes.json qdata/dd4/
-cp keys/key4 qdata/dd4/keystore
-cp raft/nodekey4 qdata/dd4/geth/nodekey
-geth --datadir qdata/dd4 init clique-genesis.json
-
-echo "[*] Configuring node 5 as voter"
-mkdir -p qdata/dd5/{keystore,geth}
-cp permissioned-nodes.json qdata/dd5/static-nodes.json
-cp permissioned-nodes.json qdata/dd5/
-cp keys/key5 qdata/dd5/keystore
-cp raft/nodekey5 qdata/dd5/geth/nodekey
-geth --datadir qdata/dd5 init clique-genesis.json
-
-echo "[*] Configuring node 6"
-mkdir -p qdata/dd6/{keystore,geth}
-cp permissioned-nodes.json qdata/dd6/static-nodes.json
-cp permissioned-nodes.json qdata/dd6/
-cp keys/key6 qdata/dd6/keystore
-cp raft/nodekey6 qdata/dd6/geth/nodekey
-geth --datadir qdata/dd6 init clique-genesis.json
-
-echo "[*] Configuring node 7"
-mkdir -p qdata/dd7/{keystore,geth}
-cp permissioned-nodes.json qdata/dd7/static-nodes.json
-cp permissioned-nodes.json qdata/dd7/
-cp keys/key7 qdata/dd7/keystore
-cp raft/nodekey7 qdata/dd7/geth/nodekey
-geth --datadir qdata/dd7 init clique-genesis.json
+for i in `seq 1 ${numNodes}`
+do
+    echo "[*] Configuring node ${i}"
+    mkdir -p qdata/dd${i}/{keystore,geth}
+    cp permissioned-nodes.json qdata/dd${i}/static-nodes.json
+    cp permissioned-nodes.json qdata/dd${i}/
+    cp keys/key${i} qdata/dd${i}/keystore
+    cp raft/nodekey${i} qdata/dd${i}/geth/nodekey
+    geth --datadir qdata/dd${i} init clique-genesis.json
+done
 
 #Initialise Tessera configuration
 ./tessera-init.sh

--- a/examples/7nodes/clique-start.sh
+++ b/examples/7nodes/clique-start.sh
@@ -11,6 +11,10 @@ function usage() {
   echo "    tessera | tessera-remote | constellation (default = tessera): specifies which privacy implementation to use"
   echo "    --tesseraOptions: allows additional options as documented in tessera-start.sh usage which is shown below:"
   echo ""
+  echo "Note that this script will examine the file qdata/numberOfNodes to"
+  echo "determine how many nodes to start up. If the file doesn't exist"
+  echo "then 7 nodes will be assumed"
+  echo ""
   ./tessera-start.sh --help
   exit -1
 }
@@ -40,7 +44,7 @@ while (( "$#" )); do
             usage
             ;;
         *)
-            echo "Error: Unsupported command line paramter $1"
+            echo "Error: Unsupported command line parameter $1"
             usage
             ;;
     esac
@@ -57,6 +61,11 @@ fi
 
 mkdir -p qdata/logs
 
+numNodes=7
+if [[ -f qdata/numberOfNodes ]]; then
+    numNodes=`cat qdata/numberOfNodes`
+fi
+
 if [ "$privacyImpl" == "tessera" ]; then
   echo "[*] Starting Tessera nodes"
   ./tessera-start.sh ${tesseraOptions}
@@ -71,17 +80,20 @@ else
   usage
 fi
 
-echo "[*] Starting Ethereum nodes with ChainID and NetworkId of $NETWORK_ID"
+echo "[*] Starting $numNodes Ethereum nodes with ChainID and NetworkId of $NETWORK_ID"
 QUORUM_GETH_ARGS=${QUORUM_GETH_ARGS:-}
 set -v
-ARGS="--nodiscover --networkid $NETWORK_ID --syncmode full --mine --minerthreads 1 --rpc --rpccorsdomain \"*\" --rpcvhosts \"*\" --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum $QUORUM_GETH_ARGS"
-echo "--datadir qdata/dd1 $ARGS --rpcport 22000 --port 21000 --unlock 0 --password passwords.txt" | PRIVATE_CONFIG=qdata/c1/tm.ipc xargs nohup geth 2>>qdata/logs/1.log &
-echo "--datadir qdata/dd2 $ARGS --rpcport 22001 --port 21001 --unlock 0 --password passwords.txt" | PRIVATE_CONFIG=qdata/c2/tm.ipc xargs nohup geth 2>>qdata/logs/2.log &
-echo "--datadir qdata/dd3 $ARGS --rpcport 22002 --port 21002 --unlock 0 --password passwords.txt" | PRIVATE_CONFIG=qdata/c3/tm.ipc xargs nohup geth 2>>qdata/logs/3.log &
-echo "--datadir qdata/dd4 $ARGS --rpcport 22003 --port 21003 --unlock 0 --password passwords.txt" | PRIVATE_CONFIG=qdata/c4/tm.ipc xargs nohup geth 2>>qdata/logs/4.log &
-echo "--datadir qdata/dd5 $ARGS --rpcport 22004 --port 21004 --unlock 0 --password passwords.txt" | PRIVATE_CONFIG=qdata/c5/tm.ipc xargs nohup geth 2>>qdata/logs/5.log &
-echo "--datadir qdata/dd6 $ARGS --rpcport 22005 --port 21005 --unlock 0 --password passwords.txt" | PRIVATE_CONFIG=qdata/c6/tm.ipc xargs nohup geth 2>>qdata/logs/6.log &
-echo "--datadir qdata/dd7 $ARGS --rpcport 22006 --port 21006 --unlock 0 --password passwords.txt" | PRIVATE_CONFIG=qdata/c7/tm.ipc xargs nohup geth 2>>qdata/logs/7.log &
+ARGS="--nodiscover --networkid $NETWORK_ID --syncmode full --mine --minerthreads 1 --rpc --rpccorsdomain \"*\" --rpcvhosts \"*\" --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum --unlock 0 --password passwords.txt $QUORUM_GETH_ARGS"
+
+basePort=21000
+baseRpcPort=22000
+for i in `seq 1 ${numNodes}`
+do
+    port=$(($basePort + ${i} - 1))
+    rpcPort=$(($baseRpcPort + ${i} - 1))
+    echo "--datadir qdata/dd${i} $ARGS --rpcport ${rpcPort} --port ${port}" | PRIVATE_CONFIG=qdata/c${i}/tm.ipc xargs nohup geth 2>>qdata/logs/${i}.log &
+done
+
 set +v
 
 echo

--- a/examples/7nodes/constellation-start.sh
+++ b/examples/7nodes/constellation-start.sh
@@ -2,7 +2,14 @@
 set -u
 set -e
 
-for i in {1..7}
+numNodes=7
+if [[ -f qdata/numberOfNodes ]]; then
+    numNodes=`cat qdata/numberOfNodes`
+fi
+
+echo "[*] Starting $numNodes Constellation node(s)"
+
+for i in `seq 1 ${numNodes}`
 do
     DDIR="qdata/c$i"
     mkdir -p $DDIR
@@ -19,7 +26,7 @@ DOWN=true
 while $DOWN; do
     sleep 0.1
     DOWN=false
-    for i in {1..7}
+    for i in `seq 1 ${numNodes}`
     do
 	if [ ! -S "qdata/c$i/tm.ipc" ]; then
             DOWN=true

--- a/examples/7nodes/istanbul-init.sh
+++ b/examples/7nodes/istanbul-init.sh
@@ -2,65 +2,80 @@
 set -u
 set -e
 
+function usage() {
+  echo ""
+  echo "Usage:"
+  echo "    $0 [--istanbulTools] [--numNodes numberOfNodes]"
+  echo ""
+  echo "Where:"
+  echo "    --istanbulTools will perform initialisation from data generated using"
+  echo "      istanbul-tools (note that permissioned-node.json and istanbul-genesis.json"
+  echo "      files will be overwritten)"
+  echo "    numberOfNodes is the number of nodes to initialise (default = $numNodes)"
+  echo ""
+  exit -1
+}
+
+istanbulTools="false"
+numNodes=7
+while (( "$#" )); do
+    case "$1" in
+        --istanbulTools)
+            istanbulTools="true"
+            shift
+            ;;
+        --numNodes)
+            re='^[0-9]+$'
+            if ! [[ $2 =~ $re ]] ; then
+                echo "ERROR: numberOfNodes value must be a number"
+                usage
+            fi
+            numNodes=$2
+            shift 2
+            ;;
+        --help)
+            shift
+            usage
+            ;;
+        *)
+            echo "Error: Unsupported command line parameter $1"
+            usage
+            ;;
+    esac
+done
+
 echo "[*] Cleaning up temporary data directories"
 rm -rf qdata
 mkdir -p qdata/logs
 
-echo "[*] Configuring node 1"
-mkdir -p qdata/dd1/{keystore,geth}
-cp permissioned-nodes.json qdata/dd1/static-nodes.json
-cp permissioned-nodes.json qdata/dd1/
-cp keys/key1 qdata/dd1/keystore
-cp raft/nodekey1 qdata/dd1/geth/nodekey
-geth --datadir qdata/dd1 init istanbul-genesis.json
+echo "[*] Configuring for $numNodes node(s)"
+echo $numNodes > qdata/numberOfNodes
 
-echo "[*] Configuring node 2"
-mkdir -p qdata/dd2/{keystore,geth}
-cp permissioned-nodes.json qdata/dd2/static-nodes.json
-cp permissioned-nodes.json qdata/dd2/
-cp keys/key2 qdata/dd2/keystore
-cp raft/nodekey2 qdata/dd2/geth/nodekey
-geth --datadir qdata/dd2 init istanbul-genesis.json
+if [[ "$istanbulTools" == "true" ]]; then
+    cp static-nodes.json permissioned-nodes.json
+    cp genesis.json istanbul-genesis.json
+fi
 
-echo "[*] Configuring node 3"
-mkdir -p qdata/dd3/{keystore,geth}
-cp permissioned-nodes.json qdata/dd3/static-nodes.json
-cp permissioned-nodes.json qdata/dd3/
-cp keys/key3 qdata/dd3/keystore
-cp raft/nodekey3 qdata/dd3/geth/nodekey
-geth --datadir qdata/dd3 init istanbul-genesis.json
+numPermissionedNodes=`grep "enode" permissioned-nodes.json |wc -l`
+if [[ $numPermissionedNodes -ne $numNodes ]]; then
+    echo "ERROR: $numPermissionedNodes nodes are configured in 'permissioned-nodes.json', but expecting configuration for $numNodes nodes"
+    exit -1
+fi
 
-echo "[*] Configuring node 4 as voter"
-mkdir -p qdata/dd4/{keystore,geth}
-cp permissioned-nodes.json qdata/dd4/static-nodes.json
-cp permissioned-nodes.json qdata/dd4/
-cp keys/key4 qdata/dd4/keystore
-cp raft/nodekey4 qdata/dd4/geth/nodekey
-geth --datadir qdata/dd4 init istanbul-genesis.json
-
-echo "[*] Configuring node 5 as voter"
-mkdir -p qdata/dd5/{keystore,geth}
-cp permissioned-nodes.json qdata/dd5/static-nodes.json
-cp permissioned-nodes.json qdata/dd5/
-cp keys/key5 qdata/dd5/keystore
-cp raft/nodekey5 qdata/dd5/geth/nodekey
-geth --datadir qdata/dd5 init istanbul-genesis.json
-
-echo "[*] Configuring node 6"
-mkdir -p qdata/dd6/{keystore,geth}
-cp permissioned-nodes.json qdata/dd6/static-nodes.json
-cp permissioned-nodes.json qdata/dd6/
-cp keys/key6 qdata/dd6/keystore
-cp raft/nodekey6 qdata/dd6/geth/nodekey
-geth --datadir qdata/dd6 init istanbul-genesis.json
-
-echo "[*] Configuring node 7"
-mkdir -p qdata/dd7/{keystore,geth}
-cp permissioned-nodes.json qdata/dd7/static-nodes.json
-cp permissioned-nodes.json qdata/dd7/
-cp keys/key7 qdata/dd7/keystore
-cp raft/nodekey7 qdata/dd7/geth/nodekey
-geth --datadir qdata/dd7 init istanbul-genesis.json
+for i in `seq 1 ${numNodes}`
+do
+    echo "[*] Configuring node ${i}"
+    mkdir -p qdata/dd${i}/{keystore,geth}
+    if [[ "$istanbulTools" == "true" ]]; then
+        iMinus1=$(($i - 1))
+        cp ${iMinus1}/nodekey qdata/dd${i}/geth/nodekey
+    else
+        cp raft/nodekey${i} qdata/dd${i}/geth/nodekey
+    fi
+    cp permissioned-nodes.json qdata/dd${i}/static-nodes.json
+    cp keys/key${i} qdata/dd${i}/keystore
+    geth --datadir qdata/dd${i} init istanbul-genesis.json
+done
 
 #Initialise Tessera configuration
 ./tessera-init.sh

--- a/examples/7nodes/istanbul-start.sh
+++ b/examples/7nodes/istanbul-start.sh
@@ -11,6 +11,10 @@ function usage() {
   echo "    tessera | tessera-remote | constellation (default = tessera): specifies which privacy implementation to use"
   echo "    --tesseraOptions: allows additional options as documented in tessera-start.sh usage which is shown below:"
   echo ""
+  echo "Note that this script will examine the file qdata/numberOfNodes to"
+  echo "determine how many nodes to start up. If the file doesn't exist"
+  echo "then 7 nodes will be assumed"
+  echo ""
   ./tessera-start.sh --help
   exit -1
 }
@@ -40,7 +44,7 @@ while (( "$#" )); do
             usage
             ;;
         *)
-            echo "Error: Unsupported command line paramter $1"
+            echo "Error: Unsupported command line parameter $1"
             usage
             ;;
     esac
@@ -57,6 +61,11 @@ fi
 
 mkdir -p qdata/logs
 
+numNodes=7
+if [[ -f qdata/numberOfNodes ]]; then
+    numNodes=`cat qdata/numberOfNodes`
+fi
+
 if [ "$privacyImpl" == "tessera" ]; then
   echo "[*] Starting Tessera nodes"
   ./tessera-start.sh ${tesseraOptions}
@@ -71,17 +80,20 @@ else
   usage
 fi
 
-echo "[*] Starting Ethereum nodes with ChainID and NetworkId of $NETWORK_ID"
+echo "[*] Starting ${numNodes} Ethereum nodes with ChainID and NetworkId of $NETWORK_ID"
 QUORUM_GETH_ARGS=${QUORUM_GETH_ARGS:-}
 set -v
-ARGS="--nodiscover --istanbul.blockperiod 5 --networkid $NETWORK_ID --syncmode full --mine --minerthreads 1 --rpc --rpccorsdomain \"*\" --rpcvhosts \"*\" --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul $QUORUM_GETH_ARGS"
-echo "--datadir qdata/dd1 $ARGS --rpcport 22000 --port 21000 --unlock 0 --password passwords.txt" | PRIVATE_CONFIG=qdata/c1/tm.ipc xargs nohup geth 2>>qdata/logs/1.log &
-echo "--datadir qdata/dd2 $ARGS --rpcport 22001 --port 21001 --unlock 0 --password passwords.txt" | PRIVATE_CONFIG=qdata/c2/tm.ipc xargs nohup geth 2>>qdata/logs/2.log &
-echo "--datadir qdata/dd3 $ARGS --rpcport 22002 --port 21002 --unlock 0 --password passwords.txt" | PRIVATE_CONFIG=qdata/c3/tm.ipc xargs nohup geth 2>>qdata/logs/3.log &
-echo "--datadir qdata/dd4 $ARGS --rpcport 22003 --port 21003 --unlock 0 --password passwords.txt" | PRIVATE_CONFIG=qdata/c4/tm.ipc xargs nohup geth 2>>qdata/logs/4.log &
-echo "--datadir qdata/dd5 $ARGS --rpcport 22004 --port 21004 --unlock 0 --password passwords.txt" | PRIVATE_CONFIG=qdata/c5/tm.ipc xargs nohup geth 2>>qdata/logs/5.log &
-echo "--datadir qdata/dd6 $ARGS --rpcport 22005 --port 21005 --unlock 0 --password passwords.txt" | PRIVATE_CONFIG=qdata/c6/tm.ipc xargs nohup geth 2>>qdata/logs/6.log &
-echo "--datadir qdata/dd7 $ARGS --rpcport 22006 --port 21006 --unlock 0 --password passwords.txt" | PRIVATE_CONFIG=qdata/c7/tm.ipc xargs nohup geth 2>>qdata/logs/7.log &
+ARGS="--nodiscover --istanbul.blockperiod 5 --networkid $NETWORK_ID --syncmode full --mine --minerthreads 1 --rpc --rpccorsdomain \"*\" --rpcvhosts \"*\" --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul --unlock 0 --password passwords.txt $QUORUM_GETH_ARGS"
+
+basePort=21000
+baseRpcPort=22000
+for i in `seq 1 ${numNodes}`
+do
+    port=$(($basePort + ${i} - 1))
+    rpcPort=$(($baseRpcPort + ${i} - 1))
+    echo "--datadir qdata/dd${i} $ARGS --rpcport ${rpcPort} --port ${port}" | PRIVATE_CONFIG=qdata/c${i}/tm.ipc xargs nohup geth 2>>qdata/logs/${i}.log &
+done
+
 set +v
 
 echo

--- a/examples/7nodes/raft-init.sh
+++ b/examples/7nodes/raft-init.sh
@@ -2,63 +2,67 @@
 set -u
 set -e
 
+function usage() {
+  echo ""
+  echo "Usage:"
+  echo "    $0 [--numNodes numberOfNodes]"
+  echo ""
+  echo "Where:"
+  echo "    numberOfNodes is the number of nodes to initialise (default = $numNodes)"
+  echo ""
+  exit -1
+}
+
+numNodes=7
+while (( "$#" )); do
+    case "$1" in
+        --numNodes)
+            re='^[0-9]+$'
+            if ! [[ $2 =~ $re ]] ; then
+                echo "ERROR: numberOfNodes value must be a number"
+                usage
+            fi
+            numNodes=$2
+            shift 2
+            ;;
+        --help)
+            shift
+            usage
+            ;;
+        *)
+            echo "Error: Unsupported command line parameter $1"
+            usage
+            ;;
+    esac
+done
+
 echo "[*] Cleaning up temporary data directories"
 rm -rf qdata
 mkdir -p qdata/logs
 
-echo "[*] Configuring node 1 (permissioned)"
-mkdir -p qdata/dd1/{keystore,geth}
-cp permissioned-nodes.json qdata/dd1/static-nodes.json
-cp permissioned-nodes.json qdata/dd1/
-cp keys/key1 qdata/dd1/keystore
-cp raft/nodekey1 qdata/dd1/geth/nodekey
-geth --datadir qdata/dd1 init genesis.json
+echo "[*] Configuring for $numNodes node(s)"
+echo $numNodes > qdata/numberOfNodes
 
-echo "[*] Configuring node 2 (permissioned)"
-mkdir -p qdata/dd2/{keystore,geth}
-cp permissioned-nodes.json qdata/dd2/static-nodes.json
-cp permissioned-nodes.json qdata/dd2/
-cp keys/key2 qdata/dd2/keystore
-cp raft/nodekey2 qdata/dd2/geth/nodekey
-geth --datadir qdata/dd2 init genesis.json
+numPermissionedNodes=`grep "enode" permissioned-nodes.json |wc -l`
+if [[ $numPermissionedNodes -ne $numNodes ]]; then
+    echo "ERROR: $numPermissionedNodes nodes are configured in 'permissioned-nodes.json', but expecting configuration for $numNodes nodes"
+    exit -1
+fi
 
-echo "[*] Configuring node 3 (permissioned)"
-mkdir -p qdata/dd3/{keystore,geth}
-cp permissioned-nodes.json qdata/dd3/static-nodes.json
-cp permissioned-nodes.json qdata/dd3/
-cp keys/key6 qdata/dd3/keystore
-cp keys/key3 qdata/dd3/keystore
-cp raft/nodekey3 qdata/dd3/geth/nodekey
-geth --datadir qdata/dd3 init genesis.json
-
-echo "[*] Configuring node 4 (permissioned)"
-mkdir -p qdata/dd4/{keystore,geth}
-cp permissioned-nodes.json qdata/dd4/static-nodes.json
-cp permissioned-nodes.json qdata/dd4/
-cp keys/key4 qdata/dd4/keystore
-cp raft/nodekey4 qdata/dd4/geth/nodekey
-geth --datadir qdata/dd4 init genesis.json
-
-echo "[*] Configuring node 5"
-mkdir -p qdata/dd5/{keystore,geth}
-cp permissioned-nodes.json qdata/dd5/static-nodes.json
-cp keys/key5 qdata/dd5/keystore
-cp raft/nodekey5 qdata/dd5/geth/nodekey
-geth --datadir qdata/dd5 init genesis.json
-
-echo "[*] Configuring node 6"
-mkdir -p qdata/dd6/{keystore,geth}
-cp permissioned-nodes.json qdata/dd6/static-nodes.json
-cp raft/nodekey6 qdata/dd6/geth/nodekey
-cp keys/key7 qdata/dd6/keystore
-geth --datadir qdata/dd6 init genesis.json
-
-echo "[*] Configuring node 7"
-mkdir -p qdata/dd7/{keystore,geth}
-cp permissioned-nodes.json qdata/dd7/static-nodes.json
-cp raft/nodekey7 qdata/dd7/geth/nodekey
-cp keys/key8 qdata/dd7/keystore
-geth --datadir qdata/dd7 init genesis.json
+for i in `seq 1 ${numNodes}`
+do
+    mkdir -p qdata/dd${i}/{keystore,geth}
+    if [[ $i -le 4 ]]; then
+        echo "[*] Configuring node $i (permissioned)"
+        cp permissioned-nodes.json qdata/dd${i}/
+    else
+        echo "[*] Configuring node $i"
+    fi
+    cp permissioned-nodes.json qdata/dd${i}/static-nodes.json
+    cp keys/key${i} qdata/dd${i}/keystore
+    cp raft/nodekey${i} qdata/dd${i}/geth/nodekey
+    geth --datadir qdata/dd${i} init genesis.json
+done
 
 #Initialise Tessera configuration
 ./tessera-init.sh

--- a/examples/7nodes/raft-start.sh
+++ b/examples/7nodes/raft-start.sh
@@ -11,6 +11,10 @@ function usage() {
   echo "    tessera | tessera-remote | constellation (default = tessera): specifies which privacy implementation to use"
   echo "    --tesseraOptions: allows additional options as documented in tessera-start.sh usage which is shown below:"
   echo ""
+  echo "Note that this script will examine the file qdata/numberOfNodes to"
+  echo "determine how many nodes to start up. If the file doesn't exist"
+  echo "then 7 nodes will be assumed"
+  echo ""
   ./tessera-start.sh --help
   exit -1
 }
@@ -57,6 +61,11 @@ fi
 
 mkdir -p qdata/logs
 
+numNodes=7
+if [[ -f qdata/numberOfNodes ]]; then
+    numNodes=`cat qdata/numberOfNodes`
+fi
+
 if [ "$privacyImpl" == "tessera" ]; then
   echo "[*] Starting Tessera nodes"
   ./tessera-start.sh ${tesseraOptions}
@@ -71,17 +80,26 @@ else
   usage
 fi
 
-echo "[*] Starting Ethereum nodes with ChainID and NetworkId of $NETWORK_ID"
+echo "[*] Starting $numNodes Ethereum nodes with ChainID and NetworkId of $NETWORK_ID"
 QUORUM_GETH_ARGS=${QUORUM_GETH_ARGS:-}
 set -v
-ARGS="--nodiscover --verbosity 5 --networkid $NETWORK_ID --raft --rpc --rpccorsdomain \"*\" --rpcvhosts \"*\" --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft --emitcheckpoints $QUORUM_GETH_ARGS"
-echo "--datadir qdata/dd1 $ARGS --permissioned --raftport 50401 --rpcport 22000 --port 21000 --unlock 0 --password passwords.txt" | PRIVATE_CONFIG=qdata/c1/tm.ipc xargs nohup geth 2>>qdata/logs/1.log &
-echo "--datadir qdata/dd2 $ARGS --permissioned --raftport 50402 --rpcport 22001 --port 21001 --unlock 0 --password passwords.txt" | PRIVATE_CONFIG=qdata/c2/tm.ipc xargs nohup geth 2>>qdata/logs/2.log &
-echo "--datadir qdata/dd3 $ARGS --permissioned --raftport 50403 --rpcport 22002 --port 21002 --unlock 0 --password passwords.txt" | PRIVATE_CONFIG=qdata/c3/tm.ipc xargs nohup geth 2>>qdata/logs/3.log &
-echo "--datadir qdata/dd4 $ARGS --permissioned --raftport 50404 --rpcport 22003 --port 21003 --unlock 0 --password passwords.txt" | PRIVATE_CONFIG=qdata/c4/tm.ipc xargs nohup geth 2>>qdata/logs/4.log &
-echo "--datadir qdata/dd5 $ARGS --raftport 50405 --rpcport 22004 --port 21004 --unlock 0 --password passwords.txt" | PRIVATE_CONFIG=qdata/c5/tm.ipc xargs nohup geth 2>>qdata/logs/5.log &
-echo "--datadir qdata/dd6 $ARGS --raftport 50406 --rpcport 22005 --port 21005 --unlock 0 --password passwords.txt" | PRIVATE_CONFIG=qdata/c6/tm.ipc xargs nohup geth 2>>qdata/logs/6.log &
-echo "--datadir qdata/dd7 $ARGS --raftport 50407 --rpcport 22006 --port 21006 --unlock 0 --password passwords.txt" | PRIVATE_CONFIG=qdata/c7/tm.ipc xargs nohup geth 2>>qdata/logs/7.log &
+ARGS="--nodiscover --verbosity 5 --networkid $NETWORK_ID --raft --rpc --rpccorsdomain \"*\" --rpcvhosts \"*\" --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft --emitcheckpoints --unlock 0 --password passwords.txt $QUORUM_GETH_ARGS"
+
+basePort=21000
+baseRpcPort=22000
+baseRaftPort=50401
+for i in `seq 1 ${numNodes}`
+do
+    port=$(($basePort + ${i} - 1))
+    rpcPort=$(($baseRpcPort + ${i} - 1))
+    raftPort=$(($baseRaftPort + ${i} - 1))
+    permissioned=
+    if [[ $i -le 4 ]]; then
+        permissioned="--permissioned"
+    fi
+    echo "--datadir qdata/dd${i} $ARGS ${permissioned} --raftport ${raftPort} --rpcport ${rpcPort} --port ${port}" | PRIVATE_CONFIG=qdata/c${i}/tm.ipc xargs nohup geth 2>>qdata/logs/${i}.log &
+done
+
 set +v
 
 echo

--- a/examples/7nodes/tessera-start.sh
+++ b/examples/7nodes/tessera-start.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+# Start Tessera nodes.
+# This script will normally start up 7 nodes, however
+# if file qdata/numberOfNodes exists then the script will read number
+# of nodes from that file.
+
 set -u
 set -e
 
@@ -12,8 +17,11 @@ function usage() {
   echo "    --remoteDebug enables remote debug on port 500n for each Tessera node (for use with JVisualVm etc)"
   echo "    --jvmParams specifies parameters to be used by JVM when running Tessera"
   echo "Notes:"
-  echo "    Tessera jar location defaults to ${defaultTesseraJarExpr};"
+  echo "  - Tessera jar location defaults to ${defaultTesseraJarExpr};"
   echo "    however, this can be overridden by environment variable TESSERA_JAR or by the command line option."
+  echo "  - This script will examine the file qdata/numberOfNodes to"
+  echo "    determine how many nodes to start up. If the file doesn't"
+  echo "    exist then 7 nodes will be assumed"
   echo ""
   exit -1
 }
@@ -76,8 +84,15 @@ fi
 
 echo Config type $TESSERA_CONFIG_TYPE
 
+numNodes=7
+if [[ -f qdata/numberOfNodes ]]; then
+    numNodes=`cat qdata/numberOfNodes`
+fi
+
+echo "[*] Starting $numNodes Tessera node(s)"
+
 currentDir=`pwd`
-for i in {1..7}
+for i in `seq 1 ${numNodes}`
 do
     DDIR="qdata/c$i"
     mkdir -p ${DDIR}
@@ -107,7 +122,7 @@ k=10
 while ${DOWN}; do
     sleep 1
     DOWN=false
-    for i in {1..7}
+    for i in `seq 1 ${numNodes}`
     do
         if [ ! -S "qdata/c${i}/tm.ipc" ]; then
             echo "Node ${i} is not yet listening on tm.ipc"


### PR DESCRIPTION
Added `--istanbulTools` option to istanbul scripts to support istanbul-tools generated config.
Also modified all init & start scripts and added `--numNodes` option to make it easier to change number of nodes.

Note that scripts are all backwards compatible & can be run same as previously for 7 nodes.