### PR TITLE
Remove xargs from startup

### DIFF
--- a/examples/7nodes/clique-start.sh
+++ b/examples/7nodes/clique-start.sh
@@ -83,7 +83,7 @@ fi
 echo "[*] Starting $numNodes Ethereum nodes with ChainID and NetworkId of $NETWORK_ID"
 QUORUM_GETH_ARGS=${QUORUM_GETH_ARGS:-}
 set -v
-ARGS="--nodiscover --networkid $NETWORK_ID --syncmode full --mine --minerthreads 1 --rpc --rpccorsdomain \"*\" --rpcvhosts \"*\" --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum --unlock 0 --password passwords.txt $QUORUM_GETH_ARGS"
+ARGS="--nodiscover --networkid $NETWORK_ID --syncmode full --mine --minerthreads 1 --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum --unlock 0 --password passwords.txt $QUORUM_GETH_ARGS"
 
 basePort=21000
 baseRpcPort=22000
@@ -91,7 +91,7 @@ for i in `seq 1 ${numNodes}`
 do
     port=$(($basePort + ${i} - 1))
     rpcPort=$(($baseRpcPort + ${i} - 1))
-    echo "--datadir qdata/dd${i} $ARGS --rpcport ${rpcPort} --port ${port}" | PRIVATE_CONFIG=qdata/c${i}/tm.ipc xargs nohup geth 2>>qdata/logs/${i}.log &
+    PRIVATE_CONFIG=qdata/c${i}/tm.ipc nohup geth --datadir qdata/dd${i} ${ARGS} --rpcport ${rpcPort} --port ${port} 2>>qdata/logs/${i}.log &
 done
 
 set +v

--- a/examples/7nodes/istanbul-start.sh
+++ b/examples/7nodes/istanbul-start.sh
@@ -83,7 +83,7 @@ fi
 echo "[*] Starting ${numNodes} Ethereum nodes with ChainID and NetworkId of $NETWORK_ID"
 QUORUM_GETH_ARGS=${QUORUM_GETH_ARGS:-}
 set -v
-ARGS="--nodiscover --istanbul.blockperiod 5 --networkid $NETWORK_ID --syncmode full --mine --minerthreads 1 --rpc --rpccorsdomain \"*\" --rpcvhosts \"*\" --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul --unlock 0 --password passwords.txt $QUORUM_GETH_ARGS"
+ARGS="--nodiscover --istanbul.blockperiod 5 --networkid $NETWORK_ID --syncmode full --mine --minerthreads 1 --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul --unlock 0 --password passwords.txt $QUORUM_GETH_ARGS"
 
 basePort=21000
 baseRpcPort=22000
@@ -91,7 +91,7 @@ for i in `seq 1 ${numNodes}`
 do
     port=$(($basePort + ${i} - 1))
     rpcPort=$(($baseRpcPort + ${i} - 1))
-    echo "--datadir qdata/dd${i} $ARGS --rpcport ${rpcPort} --port ${port}" | PRIVATE_CONFIG=qdata/c${i}/tm.ipc xargs nohup geth 2>>qdata/logs/${i}.log &
+    PRIVATE_CONFIG=qdata/c${i}/tm.ipc nohup geth --datadir qdata/dd${i} ${ARGS} --rpcport ${rpcPort} --port ${port} 2>>qdata/logs/${i}.log &
 done
 
 set +v

--- a/examples/7nodes/raft-start.sh
+++ b/examples/7nodes/raft-start.sh
@@ -83,7 +83,7 @@ fi
 echo "[*] Starting $numNodes Ethereum nodes with ChainID and NetworkId of $NETWORK_ID"
 QUORUM_GETH_ARGS=${QUORUM_GETH_ARGS:-}
 set -v
-ARGS="--nodiscover --verbosity 5 --networkid $NETWORK_ID --raft --rpc --rpccorsdomain \"*\" --rpcvhosts \"*\" --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft --emitcheckpoints --unlock 0 --password passwords.txt $QUORUM_GETH_ARGS"
+ARGS="--nodiscover --verbosity 5 --networkid $NETWORK_ID --raft --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft --emitcheckpoints --unlock 0 --password passwords.txt $QUORUM_GETH_ARGS"
 
 basePort=21000
 baseRpcPort=22000
@@ -97,7 +97,7 @@ do
     if [[ $i -le 4 ]]; then
         permissioned="--permissioned"
     fi
-    echo "--datadir qdata/dd${i} $ARGS ${permissioned} --raftport ${raftPort} --rpcport ${rpcPort} --port ${port}" | PRIVATE_CONFIG=qdata/c${i}/tm.ipc xargs nohup geth 2>>qdata/logs/${i}.log &
+    PRIVATE_CONFIG=qdata/c${i}/tm.ipc nohup geth --datadir qdata/dd${i} ${ARGS} ${permissioned} --raftport ${raftPort} --rpcport ${rpcPort} --port ${port} 2>>qdata/logs/${i}.log &
 done
 
 set +v


### PR DESCRIPTION
Remove piping into xargs for the startup script.
Use the `property=value` method of specifying the `rpccorsdomain` and `rpcvhosts` to keep the functionality.

This makes it more readable to me, interested to see what others think.