### PR TITLE
Remove PTM location from attach script

### DIFF
--- a/examples/7nodes/runscript.sh
+++ b/examples/7nodes/runscript.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-PRIVATE_CONFIG=qdata/c1/tm.ipc geth --exec "loadScript(\"$1\")" attach ipc:qdata/dd1/geth.ipc
+geth --exec "loadScript(\"$1\")" attach ipc:qdata/dd1/geth.ipc


### PR DESCRIPTION
The PTM isn't required when attaching to an existing node, but will cause a panic if the PTM isn't present. This is noticeable when running a cluster without private transactions, and so the PTMs are not started.