### PR TITLE
Correction to tessera cors config

### DIFF
--- a/examples/7nodes/tessera-init.sh
+++ b/examples/7nodes/tessera-init.sh
@@ -157,10 +157,6 @@ cat <<EOF > ${DDIR}/tessera-config-09-${i}.json
                 "clientTrustMode": "TOFU",
                 "knownServersFile": "${DDIR}/knownServers"
             },
-            "cors" : {
-                "allowedMethods" : ["GET", "OPTIONS"],
-                "allowedOrigins" : ["*"]
-            },
             "communicationType" : "REST"
         }
     ],


### PR DESCRIPTION
Tessera cors config is only supported in the ThirdParty config section.
This PR removes it from the P2P section, as that was resulting in Tessera failing to start up.
Fixes #212 .