### PR TITLE
Updates cakeshop initial nodes config to work with tessera 0.10.2 par…

### DIFF
--- a/examples/7nodes/cakeshop/7nodes.json
+++ b/examples/7nodes/cakeshop/7nodes.json
@@ -2,36 +2,36 @@
   {
     "name": "node1",
     "rpcUrl": "http://localhost:22000",
-    "transactionManagerUrl": "http://localhost:9001/partyinfo"
+    "transactionManagerUrl": "http://localhost:9081/partyinfo/keys"
   },
   {
     "name": "node2",
     "rpcUrl": "http://localhost:22001",
-    "transactionManagerUrl": "http://localhost:9002/partyinfo"
+    "transactionManagerUrl": "http://localhost:9082/partyinfo/keys"
   },
   {
     "name": "node3",
     "rpcUrl": "http://localhost:22002",
-    "transactionManagerUrl": "http://localhost:9003/partyinfo"
+    "transactionManagerUrl": "http://localhost:9083/partyinfo/keys"
   },
   {
     "name": "node4",
     "rpcUrl": "http://localhost:22003",
-    "transactionManagerUrl": "http://localhost:9004/partyinfo"
+    "transactionManagerUrl": "http://localhost:9084/partyinfo/keys"
   },
   {
     "name": "node5",
     "rpcUrl": "http://localhost:22004",
-    "transactionManagerUrl": "http://localhost:9005/partyinfo"
+    "transactionManagerUrl": "http://localhost:9085/partyinfo/keys"
   },
   {
     "name": "node6",
     "rpcUrl": "http://localhost:22005",
-    "transactionManagerUrl": "http://localhost:9006/partyinfo"
+    "transactionManagerUrl": "http://localhost:9086/partyinfo/keys"
   },
   {
     "name": "node7",
     "rpcUrl": "http://localhost:22006",
-    "transactionManagerUrl": "http://localhost:9007/partyinfo"
+    "transactionManagerUrl": "http://localhost:9087/partyinfo/keys"
   }
 ]

--- a/examples/7nodes/cakeshop/7nodes_docker.json
+++ b/examples/7nodes/cakeshop/7nodes_docker.json
@@ -2,36 +2,36 @@
   {
     "name": "node1",
     "rpcUrl": "http://host.docker.internal:22000",
-    "transactionManagerUrl": "http://host.docker.internal:9001/partyinfo"
+    "transactionManagerUrl": "http://host.docker.internal:9081/partyinfo/keys"
   },
   {
     "name": "node2",
     "rpcUrl": "http://host.docker.internal:22001",
-    "transactionManagerUrl": "http://host.docker.internal:9002/partyinfo"
+    "transactionManagerUrl": "http://host.docker.internal:9082/partyinfo/keys"
   },
   {
     "name": "node3",
     "rpcUrl": "http://host.docker.internal:22002",
-    "transactionManagerUrl": "http://host.docker.internal:9003/partyinfo"
+    "transactionManagerUrl": "http://host.docker.internal:9083/partyinfo/keys"
   },
   {
     "name": "node4",
     "rpcUrl": "http://host.docker.internal:22003",
-    "transactionManagerUrl": "http://host.docker.internal:9004/partyinfo"
+    "transactionManagerUrl": "http://host.docker.internal:9084/partyinfo/keys"
   },
   {
     "name": "node5",
     "rpcUrl": "http://host.docker.internal:22004",
-    "transactionManagerUrl": "http://host.docker.internal:9005/partyinfo"
+    "transactionManagerUrl": "http://host.docker.internal:9085/partyinfo/keys"
   },
   {
     "name": "node6",
     "rpcUrl": "http://host.docker.internal:22005",
-    "transactionManagerUrl": "http://host.docker.internal:9006/partyinfo"
+    "transactionManagerUrl": "http://host.docker.internal:9086/partyinfo/keys"
   },
   {
     "name": "node7",
     "rpcUrl": "http://host.docker.internal:22006",
-    "transactionManagerUrl": "http://host.docker.internal:9007/partyinfo"
+    "transactionManagerUrl": "http://host.docker.internal:9087/partyinfo/keys"
   }
 ]


### PR DESCRIPTION
…tyinfo endpoint

Now that 0.10.2 is included, cakeshop will use the 3rd Party partyinfo/keys endpoint instead of the old P2P one