### PR TITLE
Start 7nodes example with WebSockets support

### DIFF
--- a/examples/7nodes/istanbul-start.sh
+++ b/examples/7nodes/istanbul-start.sh
@@ -105,20 +105,22 @@ fi
 echo "[*] Starting ${numNodes} Ethereum nodes with ChainID and NetworkId of $NETWORK_ID"
 QUORUM_GETH_ARGS=${QUORUM_GETH_ARGS:-}
 set -v
-ARGS="--nodiscover --istanbul.blockperiod 5 --networkid $NETWORK_ID --syncmode full --mine --minerthreads 1 --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul,quorumPermission --unlock 0 --password passwords.txt $QUORUM_GETH_ARGS"
+ARGS="--nodiscover --istanbul.blockperiod 5 --networkid $NETWORK_ID --syncmode full --mine --minerthreads 1 --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul,quorumPermission --ws --wsaddr=localhost --wsorigins=* --wsapi admin,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul,quorumPermission --unlock 0 --password passwords.txt $QUORUM_GETH_ARGS"
 
 basePort=21000
 baseRpcPort=22000
+baseWsPort=23000
 for i in `seq 1 ${numNodes}`
 do
     port=$(($basePort + ${i} - 1))
     rpcPort=$(($baseRpcPort + ${i} - 1))
+    wsPort=$(($baseWsPort + ${i} - 1))
     permissioned=
     if ! [[ -z "${STARTPERMISSION+x}" ]] ; then
         permissioned="--permissioned"
     fi
 
-    PRIVATE_CONFIG=qdata/c${i}/tm.ipc nohup geth --datadir qdata/dd${i} ${ARGS} ${permissioned} --rpcport ${rpcPort} --port ${port} 2>>qdata/logs/${i}.log &
+    PRIVATE_CONFIG=qdata/c${i}/tm.ipc nohup geth --datadir qdata/dd${i} ${ARGS} ${permissioned} --rpcport ${rpcPort} --wsport ${wsPort} --port ${port} 2>>qdata/logs/${i}.log &
 done
 
 set +v


### PR DESCRIPTION
Starts the Quorum 7nodes example with WebSockets support. Both HTTP and WS endpoints are opened for the nodes.

Note, in order to support the `RawTransactionManager`, `web3.eth.currentProvider.host` needs to be updated before instantiating `RawTransactionManager`, ie:
```
  const web3 = new Web3('ws://localhost:23000');

  // RawTransactionManager doesn't support websockets, and uses the
  // currentProvider.host URI to communicate with the node over HTTP. Therefore, we can
  // populate currentProvider.host with our proxy HTTP endpoint, without affecting
  // web3's websocket connection.
  // @ts-ignore
  web3.eth.currentProvider.host = 'http://localhost:22000';

  const rawTransactionManager = quorumjs.RawTransactionManager(web3, {
    privateUrl: 'http://localhost: '9081'
  });
```