### PR TITLE
changes to genesis config for maxCodeSize changes

### DIFF
--- a/examples/7nodes/clique-genesis.json
+++ b/examples/7nodes/clique-genesis.json
@@ -27,8 +27,12 @@
     "eip150Hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "eip158Block": 0,
     "isQuorum": true,
-    "maxCodeSize" : 35,
-    "maxCodeSizeChangeBlock" : 0,
+    "maxCodeSizeConfig" : [
+      {
+        "block" : 0,
+        "size" : 32
+      }
+    ],
     "clique": {
       "period": 5,
       "epoch": 30000

--- a/examples/7nodes/genesis.json
+++ b/examples/7nodes/genesis.json
@@ -26,9 +26,13 @@
     "eip155Block": 0,
     "eip150Hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "eip158Block": 0,
-    "maxCodeSize": 35,
-    "maxCodeSizeChangeBlock" : 0,
-    "isQuorum": true
+    "isQuorum": true,
+    "maxCodeSizeConfig" : [
+      {
+        "block" : 0,
+        "size" : 32
+      }
+    ]
   },
   "difficulty": "0x0",
   "extraData": "0x0000000000000000000000000000000000000000000000000000000000000000",

--- a/examples/7nodes/istanbul-genesis.json
+++ b/examples/7nodes/istanbul-genesis.json
@@ -27,8 +27,12 @@
       "eip155Block": 0,
       "eip158Block": 0,
       "isQuorum": true,
-      "maxCodeSize" : 35,
-      "maxCodeSizeChangeBlock" : 0,
+      "maxCodeSizeConfig" : [
+        {
+          "block" : 0,
+          "size" : 32
+        }
+      ],
       "istanbul": {
         "epoch": 30000,
         "policy": 0,


### PR DESCRIPTION
Added `maxCodeSizeConfig` into genesis files and removed `maxCodeSize` and `maxCodeSizeChangeBlock` . The changes are inline with Quorum PR https://github.com/jpmorganchase/quorum/pull/975