### PR TITLE
Support Tessera zipped distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,12 +179,10 @@ The sample network can be created to run using Istanbul BFT, Raft or Clique POA 
 
     - If running locally:
         ```
-        ./{consensus}-start.sh tessera --tesseraOptions "--tesseraJar /path/to/tessera-app.jar"
+        TESSERA_{JAR|SCRIPT}=/path/to/jar-or-startscript ./{consensus}-start.sh
         ```
         
-        By default, `{consensus}-start.sh` will look in `/home/vagrant/tessera/tessera-app/target/tessera-app-{version}-app.jar` for the Tessera jar.  `--tesseraOptions` must be provided so that the start script looks in the correct location for the Tessera jar: 
-
-        Alternatively, the Tessera jar location can be specified by setting the environment variable `TESSERA_JAR`.
+        The `{consensus}-start.sh` scripts look for a Tessera executable at default paths unique to the Vagrant environment.  When running locally these defaults must be overriden with the `TESSERA_SCRIPT` or `TESSERA_JAR` environment variables.  Set `TESSERA_SCRIPT` when using the newer versions of Tessera distributed as a `.tar` - extract the tar and set `TESSERA_SCRIPT` to the contained runnable script.  Set `TESSERA_JAR` when using older versions of Tessera distributed as an executable `.jar`.
 
 1. You are now ready to start sending private/public transactions between the nodes
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ exist, please run `sudo rm -r /opt/vagrant/embedded/bin/curl`. This is usually d
 issues with the version of curl bundled with Vagrant.
 * If you receive the error `default: cp: cannot open '/path/to/geth.ipc' for reading: Operation not supported` after running `vagrant up`, run `./raft-init.sh` within the 7nodes directory on your local machine.  This will remove temporary files created after running 7nodes locally and will enable `vagrant up` to execute correctly.  
 
+#### Troubleshooting Vagrant: VBoxManage error during vagrant up
+
+If encountering an error like 
+```
+VBoxManage: error: Details: code NS_ERROR_FAILURE (0x80004005), component MachineWrap, interface IMachine
+``` 
+during `vagrant up` try the following:
+
+* *macOS* - Open *Security & Privacy* system preferences after VirtualBox installation.  Allow installation of software from Oracle (as described [here](https://stackoverflow.com/a/52813517)).  Uninstalling and installing VirtualBox may be required to show the prompt again.     
+* Download *VM VirtualBox Extension Pack* from [VirtualBox downloads](https://www.virtualbox.org/wiki/Downloads) (*macOS* - Also allow installation as described above).
+
 #### Troubleshooting Vagrant: Memory usage
 * The Vagrant instance is allocated 6 GB of memory.  This is defined in the `Vagrantfile`, `v.memory = 6144`.  This has been deemed a suitable value to allow the VM and examples to run as expected.  The memory allocation can be changed by updating this value and running `vagrant reload` to apply the change.
 

--- a/docker-compose-4nodes-mps.yml
+++ b/docker-compose-4nodes-mps.yml
@@ -207,9 +207,12 @@ x-tx-manager-def-node1:
           cp /examples/keys/tm6.key $${DDIR}/tm6.key
           cp /examples/keys/tm7.pub $${DDIR}/tm7.pub
           cp /examples/keys/tm7.key $${DDIR}/tm7.key
-          #extract the tessera version from the jar
-          TESSERA_VERSION=$$(unzip -p /tessera/tessera-app.jar META-INF/MANIFEST.MF | grep Tessera-Version | cut -d" " -f2)
-          echo "Tessera version (extracted from manifest file): $${TESSERA_VERSION}"
+          if [ -f "/tessera/tessera-app.jar" ]; then
+              TESSERA_VERSION=$$(unzip -p /tessera/tessera-app.jar META-INF/MANIFEST.MF | grep Tessera-Version | cut -d" " -f2)
+          else
+              TESSERA_VERSION=$$(/tessera/bin/tessera version)
+          fi
+          echo "Tessera version: $${TESSERA_VERSION}"
           # sorting versions to target correct configuration
           V08=$$(echo -e "0.8\n$${TESSERA_VERSION}" | sort -n -r -t '.' -k 1,1 -k 2,2 | head -n1)
           V09AndAbove=$$(echo -e "0.9\n$${TESSERA_VERSION}" | sort -n -r -t '.' -k 1,1 -k 2,2 | head -n1)
@@ -319,7 +322,12 @@ x-tx-manager-def-node1:
           }
       EOF
           cat $${DDIR}/tessera-config$${TESSERA_CONFIG_TYPE}.json
-          java -Xms128M -Xmx128M -jar /tessera/tessera-app.jar -configfile $${DDIR}/tessera-config$${TESSERA_CONFIG_TYPE}.json
+          if [ -f "/tessera/tessera-app.jar" ]; then
+              java -Xms128M -Xmx128M -jar /tessera/tessera-app.jar -configfile $${DDIR}/tessera-config$${TESSERA_CONFIG_TYPE}.json
+          else
+              export JAVA_OPTS="-Xms128M -Xmx128M"
+              /tessera/bin/tessera -configfile $${DDIR}/tessera-config$${TESSERA_CONFIG_TYPE}.json
+          fi
           ;;
         constellation)
           echo "socket=\"$${DDIR}/tm.ipc\"\npublickeys=[\"/examples/keys/tm$${NODE_ID}.pub\"]\n" > $${DDIR}/tm.conf
@@ -370,9 +378,12 @@ x-tx-manager-def:
         tessera)
           cp /examples/keys/tm$${NODE_ID}.pub $${DDIR}/tm.pub
           cp /examples/keys/tm$${NODE_ID}.key $${DDIR}/tm.key
-          #extract the tessera version from the jar
-          TESSERA_VERSION=$$(unzip -p /tessera/tessera-app.jar META-INF/MANIFEST.MF | grep Tessera-Version | cut -d" " -f2)
-          echo "Tessera version (extracted from manifest file): $${TESSERA_VERSION}"
+          if [ -f "/tessera/tessera-app.jar" ]; then
+              TESSERA_VERSION=$$(unzip -p /tessera/tessera-app.jar META-INF/MANIFEST.MF | grep Tessera-Version | cut -d" " -f2)
+          else
+              TESSERA_VERSION=$$(/tessera/bin/tessera version)
+          fi
+          echo "Tessera version: $${TESSERA_VERSION}"
           # sorting versions to target correct configuration
           V08=$$(echo -e "0.8\n$${TESSERA_VERSION}" | sort -n -r -t '.' -k 1,1 -k 2,2 | head -n1)
           V09AndAbove=$$(echo -e "0.9\n$${TESSERA_VERSION}" | sort -n -r -t '.' -k 1,1 -k 2,2 | head -n1)
@@ -454,7 +465,12 @@ x-tx-manager-def:
           }
       EOF
           cat $${DDIR}/tessera-config$${TESSERA_CONFIG_TYPE}.json
-          java -Xms128M -Xmx128M -jar /tessera/tessera-app.jar -configfile $${DDIR}/tessera-config$${TESSERA_CONFIG_TYPE}.json
+          if [ -f "/tessera/tessera-app.jar" ]; then
+              java -Xms128M -Xmx128M -jar /tessera/tessera-app.jar -configfile $${DDIR}/tessera-config$${TESSERA_CONFIG_TYPE}.json
+          else
+              export JAVA_OPTS="-Xms128M -Xmx128M"
+              /tessera/bin/tessera -configfile $${DDIR}/tessera-config$${TESSERA_CONFIG_TYPE}.json
+          fi
           ;;
         constellation)
           echo "socket=\"$${DDIR}/tm.ipc\"\npublickeys=[\"/examples/keys/tm$${NODE_ID}.pub\"]\n" > $${DDIR}/tm.conf

--- a/docker-compose-4nodes-mt.yml
+++ b/docker-compose-4nodes-mt.yml
@@ -244,9 +244,12 @@ x-tx-manager-def-node1:
           cp /examples/keys/tm6.key $${DDIR}/tm6.key
           cp /examples/keys/tm7.pub $${DDIR}/tm7.pub
           cp /examples/keys/tm7.key $${DDIR}/tm7.key
-          #extract the tessera version from the jar
-          TESSERA_VERSION=$$(unzip -p /tessera/tessera-app.jar META-INF/MANIFEST.MF | grep Tessera-Version | cut -d" " -f2)
-          echo "Tessera version (extracted from manifest file): $${TESSERA_VERSION}"
+          if [ -f "/tessera/tessera-app.jar" ]; then
+              TESSERA_VERSION=$$(unzip -p /tessera/tessera-app.jar META-INF/MANIFEST.MF | grep Tessera-Version | cut -d" " -f2)
+          else
+              TESSERA_VERSION=$$(/tessera/bin/tessera version)
+          fi
+          echo "Tessera version: $${TESSERA_VERSION}"
           # sorting versions to target correct configuration
           V08=$$(echo -e "0.8\n$${TESSERA_VERSION}" | sort -n -r -t '.' -k 1,1 -k 2,2 | head -n1)
           V09AndAbove=$$(echo -e "0.9\n$${TESSERA_VERSION}" | sort -n -r -t '.' -k 1,1 -k 2,2 | head -n1)
@@ -356,7 +359,12 @@ x-tx-manager-def-node1:
           }
       EOF
           cat $${DDIR}/tessera-config$${TESSERA_CONFIG_TYPE}.json
-          java -Xms128M -Xmx128M -jar /tessera/tessera-app.jar -configfile $${DDIR}/tessera-config$${TESSERA_CONFIG_TYPE}.json
+          if [ -f "/tessera/tessera-app.jar" ]; then
+              java -Xms128M -Xmx128M -jar /tessera/tessera-app.jar -configfile $${DDIR}/tessera-config$${TESSERA_CONFIG_TYPE}.json
+          else
+              export JAVA_OPTS="-Xms128M -Xmx128M"
+              /tessera/bin/tessera -configfile $${DDIR}/tessera-config$${TESSERA_CONFIG_TYPE}.json
+          fi
           ;;
         constellation)
           echo "socket=\"$${DDIR}/tm.ipc\"\npublickeys=[\"/examples/keys/tm$${NODE_ID}.pub\"]\n" > $${DDIR}/tm.conf
@@ -407,9 +415,12 @@ x-tx-manager-def:
         tessera)
           cp /examples/keys/tm$${NODE_ID}.pub $${DDIR}/tm.pub
           cp /examples/keys/tm$${NODE_ID}.key $${DDIR}/tm.key
-          #extract the tessera version from the jar
-          TESSERA_VERSION=$$(unzip -p /tessera/tessera-app.jar META-INF/MANIFEST.MF | grep Tessera-Version | cut -d" " -f2)
-          echo "Tessera version (extracted from manifest file): $${TESSERA_VERSION}"
+          if [ -f "/tessera/tessera-app.jar" ]; then
+              TESSERA_VERSION=$$(unzip -p /tessera/tessera-app.jar META-INF/MANIFEST.MF | grep Tessera-Version | cut -d" " -f2)
+          else
+              TESSERA_VERSION=$$(/tessera/bin/tessera version)
+          fi
+          echo "Tessera version: $${TESSERA_VERSION}"
           # sorting versions to target correct configuration
           V08=$$(echo -e "0.8\n$${TESSERA_VERSION}" | sort -n -r -t '.' -k 1,1 -k 2,2 | head -n1)
           V09AndAbove=$$(echo -e "0.9\n$${TESSERA_VERSION}" | sort -n -r -t '.' -k 1,1 -k 2,2 | head -n1)
@@ -491,7 +502,12 @@ x-tx-manager-def:
           }
       EOF
           cat $${DDIR}/tessera-config$${TESSERA_CONFIG_TYPE}.json
-          java -Xms128M -Xmx128M -jar /tessera/tessera-app.jar -configfile $${DDIR}/tessera-config$${TESSERA_CONFIG_TYPE}.json
+          if [ -f "/tessera/tessera-app.jar" ]; then
+              java -Xms128M -Xmx128M -jar /tessera/tessera-app.jar -configfile $${DDIR}/tessera-config$${TESSERA_CONFIG_TYPE}.json
+          else
+              export JAVA_OPTS="-Xms128M -Xmx128M"
+              /tessera/bin/tessera -configfile $${DDIR}/tessera-config$${TESSERA_CONFIG_TYPE}.json
+          fi
           ;;
         constellation)
           echo "socket=\"$${DDIR}/tm.ipc\"\npublickeys=[\"/examples/keys/tm$${NODE_ID}.pub\"]\n" > $${DDIR}/tm.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,9 +109,12 @@ x-tx-manager-def:
         tessera)
           cp /examples/keys/tm$${NODE_ID}.pub $${DDIR}/tm.pub
           cp /examples/keys/tm$${NODE_ID}.key $${DDIR}/tm.key
-          #extract the tessera version from the jar
-          TESSERA_VERSION=$$(unzip -p /tessera/tessera-app.jar META-INF/MANIFEST.MF | grep Tessera-Version | cut -d" " -f2)
-          echo "Tessera version (extracted from manifest file): $${TESSERA_VERSION}"
+          if [ -f "/tessera/tessera-app.jar" ]; then
+              TESSERA_VERSION=$$(unzip -p /tessera/tessera-app.jar META-INF/MANIFEST.MF | grep Tessera-Version | cut -d" " -f2)
+          else
+              TESSERA_VERSION=$$(/tessera/bin/tessera version)
+          fi
+          echo "Tessera version: $${TESSERA_VERSION}"
           # sorting versions to target correct configuration
           V08=$$(echo -e "0.8\n$${TESSERA_VERSION}" | sort -n -r -t '.' -k 1,1 -k 2,2 | head -n1)
           V09AndAbove=$$(echo -e "0.9\n$${TESSERA_VERSION}" | sort -n -r -t '.' -k 1,1 -k 2,2 | head -n1)
@@ -193,7 +196,12 @@ x-tx-manager-def:
           }
       EOF
           cat $${DDIR}/tessera-config$${TESSERA_CONFIG_TYPE}.json
-          java -Xms128M -Xmx128M -jar /tessera/tessera-app.jar -configfile $${DDIR}/tessera-config$${TESSERA_CONFIG_TYPE}.json
+          if [ -f "/tessera/tessera-app.jar" ]; then
+              java -Xms128M -Xmx128M -jar /tessera/tessera-app.jar -configfile $${DDIR}/tessera-config$${TESSERA_CONFIG_TYPE}.json
+          else
+              export JAVA_OPTS="-Xms128M -Xmx128M"
+              /tessera/bin/tessera -configfile $${DDIR}/tessera-config$${TESSERA_CONFIG_TYPE}.json
+          fi
           ;;
         constellation)
           echo "socket=\"$${DDIR}/tm.ipc\"\npublickeys=[\"/examples/keys/tm$${NODE_ID}.pub\"]\n" > $${DDIR}/tm.conf

--- a/examples/7nodes/stop.sh
+++ b/examples/7nodes/stop.sh
@@ -5,6 +5,9 @@ killall constellation-node
 if [ "`jps | grep tessera`" != "" ]
 then
     jps | grep tessera | cut -d " " -f1 | xargs kill
+elif [ "`jps | grep Main`" != "" ]
+then
+    jps | grep Main | cut -d " " -f1 | xargs kill
 else
     echo "tessera: no process found"
 fi

--- a/examples/7nodes/tessera-init.sh
+++ b/examples/7nodes/tessera-init.sh
@@ -42,25 +42,14 @@ encryptorType=${ENCRYPTOR_TYPE:-NACL}
 encryptorProps=""
 
 if [ "$encryptorType" == "EC" ]; then
-    defaultTesseraJarExpr="/home/vagrant/tessera/tessera.jar"
-    set +e
-    defaultTesseraJar=`find ${defaultTesseraJarExpr} 2>/dev/null`
-    set -e
-    tesseraScript=${TESSERA_SCRIPT:-""}
-    if [[ "${tesseraScript:-unset}" == "unset" ]] && [[ "${TESSERA_JAR:-unset}" == "unset" ]]; then
-        tesseraJar=${defaultTesseraJar}
-    else
-        tesseraJar=${TESSERA_JAR}
-    fi
+    tesseraJarDefault="/home/vagrant/tessera/tessera.jar"
+    tesseraScriptDefault="/home/vagrant/tessera/tessera/bin/tessera"
 
-    if [ "${tesseraJar}" == "" ] && [ "${tesseraScript}" == "" ]; then
-        echo "ERROR: unable to find Tessera jar or script file using TESSERA_JAR and TESSERA_SCRIPT envvars, or using default jar location ${defaultTesseraJarExpr}"
-        exit -1
-    elif [ "${tesseraJar}" != "" ] && [  ! -f "${tesseraJar}" ]; then
-        echo "ERROR: unable to find Tessera jar file: ${tesseraJar}"
-        exit -1
-    elif [ "${tesseraScript}" != "" ] && [  ! -f "${tesseraScript}" ]; then
-        echo "ERROR: unable to find Tessera script file: ${tesseraScript}"
+    tesseraJar=${TESSERA_JAR:-$tesseraJarDefault}
+    tesseraScript=${TESSERA_SCRIPT:-$tesseraScriptDefault}
+
+    if [ ! -f "${tesseraJar}" ] && [ ! -f "${tesseraScript}" ]; then
+        echo "ERROR: no Tessera jar or executable script found at ${tesseraJar} or ${tesseraScript}. Use TESSERA_JAR or TESSERA_SCRIPT env vars to specify the path to an executable jar or script."
         exit -1
     fi
 
@@ -262,12 +251,11 @@ EOF
 
     #generate tessera keys
     if [ "$encryptorType" == "EC" ]; then
-        if [ "${tesseraJar}" != "" ]; then
+        if [ -f "${tesseraJar}" ]; then
             tesseraExec="java -jar ${tesseraJar}"
         else
             tesseraExec=${tesseraScript}
         fi
-
         pushd $DDIR
         $tesseraExec -keygen $encryptorCmdLineParams -filename tm < /dev/null
         popd

--- a/examples/7nodes/tessera-start-remote.sh
+++ b/examples/7nodes/tessera-start-remote.sh
@@ -13,9 +13,12 @@ function usage() {
   echo "    --jvmParams specifies parameters to be used by JVM when running Tessera"
   echo "    --remoteEnclaves specifies the number of nodes that should be using a remote enclave"
   echo "Notes:"
-  echo "    Tessera jar location defaults to ${defaultTesseraJarExpr};"
-  echo "    Enclave jar location defaults to ${defaultEnclaveJarExpr};"
-  echo "    however, this can be overridden by environment variable TESSERA_JAR or ENCLAVE_JAR or by the command line option."
+  echo "  - Tessera/Enclave .jar and extracted .tar dists supported."
+  echo "    Tessera jar location defaults to ${tesseraJarDefault}."
+  echo "    Tessera extracted runscript location defaults to ${tesseraScriptDefault}."
+  echo "    Enclave jar location defaults to ${enclaveJarDefault};"
+  echo "    Enclave extracted runscript location defaults to ${enclaveScriptDefault};"
+  echo "    Environment variables TESSERA_JAR, TESSERA_SCRIPT, ENCLAVE_JAR, and ENCLAVE_SCRIPT can be used to override these defaults."
   echo ""
   exit -1
 }

--- a/examples/7nodes/tessera-start.sh
+++ b/examples/7nodes/tessera-start.sh
@@ -17,8 +17,10 @@ function usage() {
   echo "    --remoteDebug enables remote debug on port 500n for each Tessera node (for use with JVisualVm etc)"
   echo "    --jvmParams specifies parameters to be used by JVM when running Tessera"
   echo "Notes:"
-  echo "  - Tessera jar location defaults to ${defaultTesseraJarExpr};"
-  echo "    however, this can be overridden by environment variable TESSERA_JAR or by the command line option."
+  echo "  - Tessera .jar and extracted .tar dists supported."
+  echo "    Tessera jar location defaults to ${tesseraJarDefault}".
+  echo "    Tessera runscript location defaults to ${tesseraScriptDefault}".
+  echo "    Environment variables TESSERA_JAR and TESSERA_SCRIPT can be used to override these defaults."
   echo "  - This script will examine the file qdata/numberOfNodes to"
   echo "    determine how many nodes to start up. If the file doesn't"
   echo "    exist then 7 nodes will be assumed"

--- a/examples/adding_nodes/tessera-add.yml
+++ b/examples/adding_nodes/tessera-add.yml
@@ -115,7 +115,12 @@ x-tx-manager-def:
       }
       EOF
 
-      java -Xms128M -Xmx128M -jar /tessera/tessera-app.jar -configfile $${DDIR}/tessera-config.json
+      if [ -f "/tessera/tessera-app.jar" ]; then
+          java -Xms128M -Xmx128M -jar /tessera/tessera-app.jar -configfile $${DDIR}/tessera-config.json
+      else
+          export JAVA_OPTS="-Xms128M -Xmx128M"
+          /tessera/bin/tessera -configfile $${DDIR}/tessera-config$${TESSERA_CONFIG_TYPE}.json
+      fi
 services:
   node1:
     << : *quorum-def

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -82,10 +82,13 @@ chmod 0755 ${SOLC_OUTPUT_FILE}
 echo "Installing Tessera ${TESSERA_VERSION}"
 
 if [ "$TESSERA_VERSION" \> "21.7.0" ] || [ "$TESSERA_VERSION" == "21.7.0" ]; then
-    tar --strip-components 1 --directory ${TESSERA_HOME} -xvf ${TESSERA_OUTPUT_FILE}
+    mkdir ${TESSERA_HOME}/tessera
+    mkdir ${TESSERA_HOME}/enclave-jaxrs
+    tar --strip-components 1 --directory ${TESSERA_HOME}/tessera -xvf ${TESSERA_OUTPUT_FILE}
+    tar --strip-components 1 --directory ${TESSERA_HOME}/enclave-jaxrs -xvf ${TESSERA_ENCLAVE_OUTPUT_FILE}
 
-    echo "TESSERA_SCRIPT=${TESSERA_OUTPUT_FILE}" >> /home/vagrant/.profile
-    echo "ENCLAVE_SCRIPT=${TESSERA_ENCLAVE_OUTPUT_FILE}" >> /home/vagrant/.profile
+    echo "TESSERA_SCRIPT=${TESSERA_HOME}/tessera/bin/tessera" >> /home/vagrant/.profile
+    echo "ENCLAVE_SCRIPT=${TESSERA_HOME}/enclave-jaxrs/bin/enclave-jaxrs" >> /home/vagrant/.profile
 else
     echo "TESSERA_JAR=${TESSERA_OUTPUT_FILE}" >> /home/vagrant/.profile
     echo "ENCLAVE_JAR=${TESSERA_ENCLAVE_OUTPUT_FILE}" >> /home/vagrant/.profile

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -27,8 +27,19 @@ SOLC_OUTPUT_FILE="/usr/local/bin/solc"
 TESSERA_HOME=/home/vagrant/tessera
 mkdir -p ${TESSERA_HOME}
 TESSERA_VERSION="21.4.1"
-TESSERA_OUTPUT_FILE="${TESSERA_HOME}/tessera.jar"
-TESSERA_ENCLAVE_OUTPUT_FILE="${TESSERA_HOME}/enclave.jar"
+if [ "$TESSERA_VERSION" \> "21.7.0" ] || [ "$TESSERA_VERSION" == "21.7.0" ]; then
+    TESSERA_DL_URL="https://oss.sonatype.org/content/groups/public/net/consensys/quorum/tessera/tessera-dist/${TESSERA_VERSION}/tessera-dist-${TESSERA_VERSION}.tar"
+    TESSERA_ENCLAVE_DL_URL="https://oss.sonatype.org/content/groups/public/net/consensys/quorum/tessera/enclave-jaxrs/${TESSERA_VERSION}/enclave-jaxrs-${TESSERA_VERSION}.tar"
+
+    TESSERA_OUTPUT_FILE="${TESSERA_HOME}/tessera.tar"
+    TESSERA_ENCLAVE_OUTPUT_FILE="${TESSERA_HOME}/enclave.tar"
+else
+    TESSERA_DL_URL="https://oss.sonatype.org/content/groups/public/net/consensys/quorum/tessera/tessera-app/${TESSERA_VERSION}/tessera-app-${TESSERA_VERSION}-app.jar"
+    TESSERA_ENCLAVE_DL_URL="https://oss.sonatype.org/content/groups/public/net/consensys/quorum/tessera/enclave-jaxrs/${TESSERA_VERSION}/enclave-jaxrs-${TESSERA_VERSION}-server.jar"
+
+    TESSERA_OUTPUT_FILE="${TESSERA_HOME}/tessera.jar"
+    TESSERA_ENCLAVE_OUTPUT_FILE="${TESSERA_HOME}/enclave.jar"
+fi
 
 CAKESHOP_HOME=/home/vagrant/cakeshop
 mkdir -p ${CAKESHOP_HOME}
@@ -50,8 +61,8 @@ parallel --link wget -q -O ::: \
     ${SOLC_OUTPUT_FILE} \
     ::: \
     https://github.com/jpmorganchase/constellation/releases/download/v$CVER/$CREL.tar.xz \
-    https://oss.sonatype.org/content/groups/public/net/consensys/quorum/tessera/tessera-app/${TESSERA_VERSION}/tessera-app-${TESSERA_VERSION}-app.jar \
-    https://oss.sonatype.org/content/groups/public/net/consensys/quorum/tessera/enclave-jaxrs/${TESSERA_VERSION}/enclave-jaxrs-${TESSERA_VERSION}-server.jar \
+    ${TESSERA_DL_URL} \
+    ${TESSERA_ENCLAVE_DL_URL} \
     https://artifacts.consensys.net/public/go-quorum/raw/versions/v${QUORUM_VERSION}/geth_v${QUORUM_VERSION}_linux_amd64.tar.gz \
     https://github.com/jpmorganchase/quorum/releases/download/v1.2.0/porosity \
     https://github.com/jpmorganchase/cakeshop/releases/download/v${CAKESHOP_VERSION}/cakeshop-${CAKESHOP_VERSION}.war \
@@ -69,8 +80,16 @@ chmod 0755 ${SOLC_OUTPUT_FILE}
 
 # install tessera
 echo "Installing Tessera ${TESSERA_VERSION}"
-echo "TESSERA_JAR=${TESSERA_OUTPUT_FILE}" >> /home/vagrant/.profile
-echo "ENCLAVE_JAR=${TESSERA_ENCLAVE_OUTPUT_FILE}" >> /home/vagrant/.profile
+
+if [ "$TESSERA_VERSION" \> "21.7.0" ] || [ "$TESSERA_VERSION" == "21.7.0" ]; then
+    tar --strip-components 1 --directory ${TESSERA_HOME} -xvf ${TESSERA_OUTPUT_FILE}
+
+    echo "TESSERA_SCRIPT=${TESSERA_OUTPUT_FILE}" >> /home/vagrant/.profile
+    echo "ENCLAVE_SCRIPT=${TESSERA_ENCLAVE_OUTPUT_FILE}" >> /home/vagrant/.profile
+else
+    echo "TESSERA_JAR=${TESSERA_OUTPUT_FILE}" >> /home/vagrant/.profile
+    echo "ENCLAVE_JAR=${TESSERA_ENCLAVE_OUTPUT_FILE}" >> /home/vagrant/.profile
+fi
 
 # install Quorum
 echo "Installing Quorum ${QUORUM_VERSION}"


### PR DESCRIPTION
Add support for Tessera's future .tar and .zip dists to local, vagrant, and docker-compose examples.

Extracted/unzipped run scripts can be specified using TESSERA_SCRIPT and ENCLAVE_SCRIPT environment variables.

Previously released .jar distributions can still be used as before.

**Note: Assumes [Tessera PR 1307](https://github.com/ConsenSys/tessera/pull/1307) has been merged.**

