### PR TITLE
Add examples for privacy marker transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ during `vagrant up` try the following:
    ```sh
    PRIVATE_CONFIG=ignore QUORUM_CONSENSUS=raft docker-compose up -d
    ```
+   Note that additional geth command line parameters can also be specified via the environment variable `QUORUM_GETH_ARGS`
 1. Run `docker ps` to verify that all quorum-examples containers (7 nodes and 7 tx managers) are **healthy**
 1. Run `docker logs <container-name> -f` to view the logs for a particular container
 1. __Note__: to run the 7nodes demo, use the following snippet to open `geth` Javascript console to a desired node (using container name from `docker ps`) and send a private transaction

--- a/docker-compose-4nodes-mps.yml
+++ b/docker-compose-4nodes-mps.yml
@@ -1,7 +1,7 @@
 # The following environment variables are substituted if present
 # * QUORUM_CONSENSUS: default to istanbul
-# * QUORUM_DOCKER_IMAGE: default to quorumengineering/quorum:2.6.0
-# * QUORUM_TX_MANAGER_DOCKER_IMAGE: default to quorumengineering/tessera:0.10.6
+# * QUORUM_DOCKER_IMAGE: default to quorumengineering/quorum:21.7.1
+# * QUORUM_TX_MANAGER_DOCKER_IMAGE: default to quorumengineering/tessera:21.7.2
 # * QUORUM_GETH_ARGS: extra geth arguments to be included when running geth
 # To use Constellation, set QUORUM_TX_MANAGER_DOCKER_IMAGE to Constellation docker image,
 # e.g.: QUORUM_TX_MANAGER_DOCKER_IMAGE=quorumengineering/constellation:0.3.2 docker-compose up -d
@@ -10,7 +10,7 @@ version: "3.6"
 x-quorum-def-node1:
   &quorum-def-node1
   restart: "on-failure"
-  image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:develop}"
+  image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:21.7.1}"
   expose:
     - "21000"
     - "50400"
@@ -94,7 +94,7 @@ x-quorum-def-node1:
 x-quorum-def:
   &quorum-def
   restart: "on-failure"
-  image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:develop}"
+  image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:21.7.1}"
   expose:
     - "21000"
     - "50400"
@@ -171,7 +171,7 @@ x-quorum-def:
         ${QUORUM_GETH_ARGS:-} $${GETH_ARGS_${QUORUM_CONSENSUS:-istanbul}}
 x-tx-manager-def-node1:
   &tx-manager-def-node1
-  image: "${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:develop}"
+  image: "${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7.2}"
   expose:
     - "9000"
     - "9080"
@@ -193,7 +193,7 @@ x-tx-manager-def-node1:
       DDIR=/qdata/tm
       rm -rf $${DDIR}
       mkdir -p $${DDIR}
-      DOCKER_IMAGE="${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:0.10.6}"
+      DOCKER_IMAGE="${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7.2}"
       TX_MANAGER=$$(echo $${DOCKER_IMAGE} | sed 's/^.*\/\(.*\):.*$$/\1/g')
       echo "TxManager: $${TX_MANAGER}"
       case $${TX_MANAGER}
@@ -348,7 +348,7 @@ x-tx-manager-def-node1:
       esac
 x-tx-manager-def:
   &tx-manager-def
-  image: "${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:develop}"
+  image: "${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7.2}"
   expose:
     - "9000"
     - "9080"
@@ -370,7 +370,7 @@ x-tx-manager-def:
       DDIR=/qdata/tm
       rm -rf $${DDIR}
       mkdir -p $${DDIR}
-      DOCKER_IMAGE="${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:0.10.6}"
+      DOCKER_IMAGE="${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7.2}"
       TX_MANAGER=$$(echo $${DOCKER_IMAGE} | sed 's/^.*\/\(.*\):.*$$/\1/g')
       echo "TxManager: $${TX_MANAGER}"
       case $${TX_MANAGER}
@@ -491,7 +491,7 @@ x-tx-manager-def:
       esac
 x-cakeshop-def:
   &cakeshop-def
-  image: "${CAKESHOP_DOCKER_IMAGE:-quorumengineering/cakeshop:0.11.0}"
+  image: "${CAKESHOP_DOCKER_IMAGE:-quorumengineering/cakeshop:0.12.1}"
   expose:
     - "8999"
   restart: "no"
@@ -508,7 +508,7 @@ x-cakeshop-def:
       DDIR=/qdata/cakeshop/local
       rm -rf $${DDIR}
       mkdir -p $${DDIR}
-      DOCKER_IMAGE="${CAKESHOP_DOCKER_IMAGE:-quorumengineering/cakeshop:0.11.0}"
+      DOCKER_IMAGE="${CAKESHOP_DOCKER_IMAGE:-quorumengineering/cakeshop:0.12.1}"
       cp /examples/cakeshop/application.properties.template $${DDIR}/application.properties
       cp /examples/cakeshop/7nodes_docker.json $${DDIR}/7nodes.json
       java -Xms128M -Xmx128M -Dcakeshop.config.dir=/qdata/cakeshop -Dlogging.path=/qdata/logs/cakeshop -jar /opt/cakeshop/cakeshop.war

--- a/docker-compose-4nodes-mps.yml
+++ b/docker-compose-4nodes-mps.yml
@@ -1,7 +1,7 @@
 # The following environment variables are substituted if present
 # * QUORUM_CONSENSUS: default to istanbul
-# * QUORUM_DOCKER_IMAGE: default to quorumengineering/quorum:21.7.1
-# * QUORUM_TX_MANAGER_DOCKER_IMAGE: default to quorumengineering/tessera:21.7.2
+# * QUORUM_DOCKER_IMAGE: default to quorumengineering/quorum:21.7
+# * QUORUM_TX_MANAGER_DOCKER_IMAGE: default to quorumengineering/tessera:21.7
 # * QUORUM_GETH_ARGS: extra geth arguments to be included when running geth
 # To use Constellation, set QUORUM_TX_MANAGER_DOCKER_IMAGE to Constellation docker image,
 # e.g.: QUORUM_TX_MANAGER_DOCKER_IMAGE=quorumengineering/constellation:0.3.2 docker-compose up -d
@@ -10,7 +10,7 @@ version: "3.6"
 x-quorum-def-node1:
   &quorum-def-node1
   restart: "on-failure"
-  image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:21.7.1}"
+  image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:21.7}"
   expose:
     - "21000"
     - "50400"
@@ -59,7 +59,7 @@ x-quorum-def-node1:
       if [ "${QUORUM_CONSENSUS:-istanbul}" == "istanbul" ]; then
         GENESIS_FILE="/examples/istanbul-genesis.json"
         #set the extradata for 4 nodes
-        UPDATE_QUERY=$${UPDATE_QUERY}' | .extraData = "0x0000000000000000000000000000000000000000000000000000000000000000f89af85494d8dba507e85f116b1f7e231ca8525fc9008a6966946571d97f340c8495b661a823f2c2145ca47d63c294e36cbeb565b061217930767886474e3cde903ac594f512a992f3fb749857d758ffda1330e590fa915eb8410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c0"'
+        UPDATE_QUERY=$${UPDATE_QUERY}' | .extraData = "0xf87aa00000000000000000000000000000000000000000000000000000000000000000f85494d8dba507e85f116b1f7e231ca8525fc9008a6966946571d97f340c8495b661a823f2c2145ca47d63c294e36cbeb565b061217930767886474e3cde903ac594f512a992f3fb749857d758ffda1330e590fa915ec080c0"'
       fi
       MPS_GENESIS_FILE=$${DDIR}/mps-genesis.json
       echo "JQ Update Query:" $${UPDATE_QUERY}
@@ -94,7 +94,7 @@ x-quorum-def-node1:
 x-quorum-def:
   &quorum-def
   restart: "on-failure"
-  image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:21.7.1}"
+  image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:21.7}"
   expose:
     - "21000"
     - "50400"
@@ -140,7 +140,7 @@ x-quorum-def:
       if [ "${QUORUM_CONSENSUS:-istanbul}" == "istanbul" ]; then
         GENESIS_FILE="/examples/istanbul-genesis.json"
         #set the extradata for 4 nodes
-        UPDATE_QUERY=$${UPDATE_QUERY}' | .extraData = "0x0000000000000000000000000000000000000000000000000000000000000000f89af85494d8dba507e85f116b1f7e231ca8525fc9008a6966946571d97f340c8495b661a823f2c2145ca47d63c294e36cbeb565b061217930767886474e3cde903ac594f512a992f3fb749857d758ffda1330e590fa915eb8410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c0"'
+        UPDATE_QUERY=$${UPDATE_QUERY}' | .extraData = "0xf87aa00000000000000000000000000000000000000000000000000000000000000000f85494d8dba507e85f116b1f7e231ca8525fc9008a6966946571d97f340c8495b661a823f2c2145ca47d63c294e36cbeb565b061217930767886474e3cde903ac594f512a992f3fb749857d758ffda1330e590fa915ec080c0"'
       fi
       MPS_GENESIS_FILE=$${DDIR}/mps-genesis.json
       echo "JQ Update Query:" $${UPDATE_QUERY}
@@ -171,7 +171,7 @@ x-quorum-def:
         ${QUORUM_GETH_ARGS:-} $${GETH_ARGS_${QUORUM_CONSENSUS:-istanbul}}
 x-tx-manager-def-node1:
   &tx-manager-def-node1
-  image: "${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7.2}"
+  image: "${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7}"
   expose:
     - "9000"
     - "9080"
@@ -193,7 +193,7 @@ x-tx-manager-def-node1:
       DDIR=/qdata/tm
       rm -rf $${DDIR}
       mkdir -p $${DDIR}
-      DOCKER_IMAGE="${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7.2}"
+      DOCKER_IMAGE="${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7}"
       TX_MANAGER=$$(echo $${DOCKER_IMAGE} | sed 's/^.*\/\(.*\):.*$$/\1/g')
       echo "TxManager: $${TX_MANAGER}"
       case $${TX_MANAGER}
@@ -348,7 +348,7 @@ x-tx-manager-def-node1:
       esac
 x-tx-manager-def:
   &tx-manager-def
-  image: "${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7.2}"
+  image: "${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7}"
   expose:
     - "9000"
     - "9080"
@@ -370,7 +370,7 @@ x-tx-manager-def:
       DDIR=/qdata/tm
       rm -rf $${DDIR}
       mkdir -p $${DDIR}
-      DOCKER_IMAGE="${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7.2}"
+      DOCKER_IMAGE="${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7}"
       TX_MANAGER=$$(echo $${DOCKER_IMAGE} | sed 's/^.*\/\(.*\):.*$$/\1/g')
       echo "TxManager: $${TX_MANAGER}"
       case $${TX_MANAGER}

--- a/docker-compose-4nodes-mt.yml
+++ b/docker-compose-4nodes-mt.yml
@@ -1,7 +1,7 @@
 # The following environment variables are substituted if present
 # * QUORUM_CONSENSUS: default to istanbul
-# * QUORUM_DOCKER_IMAGE: default to quorumengineering/quorum:2.6.0
-# * QUORUM_TX_MANAGER_DOCKER_IMAGE: default to quorumengineering/tessera:0.10.6
+# * QUORUM_DOCKER_IMAGE: default to quorumengineering/quorum:21.7.1
+# * QUORUM_TX_MANAGER_DOCKER_IMAGE: default to quorumengineering/tessera:21.7.2
 # * QUORUM_GETH_ARGS: extra geth arguments to be included when running geth
 # To use Constellation, set QUORUM_TX_MANAGER_DOCKER_IMAGE to Constellation docker image,
 # e.g.: QUORUM_TX_MANAGER_DOCKER_IMAGE=quorumengineering/constellation:0.3.2 docker-compose up -d
@@ -10,7 +10,7 @@ version: "3.6"
 x-quorum-def-node1:
   &quorum-def-node1
   restart: "on-failure"
-  image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:develop}"
+  image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:21.7.1}"
   expose:
     - "21000"
     - "50400"
@@ -131,7 +131,7 @@ x-quorum-def-node1:
 x-quorum-def:
   &quorum-def
   restart: "on-failure"
-  image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:develop}"
+  image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:21.7.1}"
   expose:
     - "21000"
     - "50400"
@@ -208,7 +208,7 @@ x-quorum-def:
         ${QUORUM_GETH_ARGS:-} $${GETH_ARGS_${QUORUM_CONSENSUS:-istanbul}}
 x-tx-manager-def-node1:
   &tx-manager-def-node1
-  image: "${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:develop}"
+  image: "${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7.2}"
   expose:
     - "9000"
     - "9080"
@@ -230,7 +230,7 @@ x-tx-manager-def-node1:
       DDIR=/qdata/tm
       rm -rf $${DDIR}
       mkdir -p $${DDIR}
-      DOCKER_IMAGE="${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:0.10.6}"
+      DOCKER_IMAGE="${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7.2}"
       TX_MANAGER=$$(echo $${DOCKER_IMAGE} | sed 's/^.*\/\(.*\):.*$$/\1/g')
       echo "TxManager: $${TX_MANAGER}"
       case $${TX_MANAGER}
@@ -385,7 +385,7 @@ x-tx-manager-def-node1:
       esac
 x-tx-manager-def:
   &tx-manager-def
-  image: "${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:develop}"
+  image: "${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7.2}"
   expose:
     - "9000"
     - "9080"
@@ -407,7 +407,7 @@ x-tx-manager-def:
       DDIR=/qdata/tm
       rm -rf $${DDIR}
       mkdir -p $${DDIR}
-      DOCKER_IMAGE="${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:0.10.6}"
+      DOCKER_IMAGE="${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7.2}"
       TX_MANAGER=$$(echo $${DOCKER_IMAGE} | sed 's/^.*\/\(.*\):.*$$/\1/g')
       echo "TxManager: $${TX_MANAGER}"
       case $${TX_MANAGER}
@@ -528,7 +528,7 @@ x-tx-manager-def:
       esac
 x-cakeshop-def:
   &cakeshop-def
-  image: "${CAKESHOP_DOCKER_IMAGE:-quorumengineering/cakeshop:0.11.0}"
+  image: "${CAKESHOP_DOCKER_IMAGE:-quorumengineering/cakeshop:0.12.1}"
   expose:
     - "8999"
   restart: "no"
@@ -545,7 +545,7 @@ x-cakeshop-def:
       DDIR=/qdata/cakeshop/local
       rm -rf $${DDIR}
       mkdir -p $${DDIR}
-      DOCKER_IMAGE="${CAKESHOP_DOCKER_IMAGE:-quorumengineering/cakeshop:0.11.0}"
+      DOCKER_IMAGE="${CAKESHOP_DOCKER_IMAGE:-quorumengineering/cakeshop:0.12.1}"
       cp /examples/cakeshop/application.properties.template $${DDIR}/application.properties
       cp /examples/cakeshop/7nodes_docker.json $${DDIR}/7nodes.json
       java -Xms128M -Xmx128M -Dcakeshop.config.dir=/qdata/cakeshop -Dlogging.path=/qdata/logs/cakeshop -jar /opt/cakeshop/cakeshop.war

--- a/docker-compose-4nodes-mt.yml
+++ b/docker-compose-4nodes-mt.yml
@@ -1,7 +1,7 @@
 # The following environment variables are substituted if present
 # * QUORUM_CONSENSUS: default to istanbul
-# * QUORUM_DOCKER_IMAGE: default to quorumengineering/quorum:21.7.1
-# * QUORUM_TX_MANAGER_DOCKER_IMAGE: default to quorumengineering/tessera:21.7.2
+# * QUORUM_DOCKER_IMAGE: default to quorumengineering/quorum:21.7
+# * QUORUM_TX_MANAGER_DOCKER_IMAGE: default to quorumengineering/tessera:21.7
 # * QUORUM_GETH_ARGS: extra geth arguments to be included when running geth
 # To use Constellation, set QUORUM_TX_MANAGER_DOCKER_IMAGE to Constellation docker image,
 # e.g.: QUORUM_TX_MANAGER_DOCKER_IMAGE=quorumengineering/constellation:0.3.2 docker-compose up -d
@@ -10,7 +10,7 @@ version: "3.6"
 x-quorum-def-node1:
   &quorum-def-node1
   restart: "on-failure"
-  image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:21.7.1}"
+  image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:21.7}"
   expose:
     - "21000"
     - "50400"
@@ -93,7 +93,7 @@ x-quorum-def-node1:
       if [ "${QUORUM_CONSENSUS:-istanbul}" == "istanbul" ]; then
         GENESIS_FILE="/examples/istanbul-genesis.json"
         #set the extradata for 4 nodes
-        UPDATE_QUERY=$${UPDATE_QUERY}' | .extraData = "0x0000000000000000000000000000000000000000000000000000000000000000f89af85494d8dba507e85f116b1f7e231ca8525fc9008a6966946571d97f340c8495b661a823f2c2145ca47d63c294e36cbeb565b061217930767886474e3cde903ac594f512a992f3fb749857d758ffda1330e590fa915eb8410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c0"'
+        UPDATE_QUERY=$${UPDATE_QUERY}' | .extraData = "0xf87aa00000000000000000000000000000000000000000000000000000000000000000f85494d8dba507e85f116b1f7e231ca8525fc9008a6966946571d97f340c8495b661a823f2c2145ca47d63c294e36cbeb565b061217930767886474e3cde903ac594f512a992f3fb749857d758ffda1330e590fa915ec080c0"'
       fi
       MPS_GENESIS_FILE=$${DDIR}/mps-genesis.json
       echo "JQ Update Query:" $${UPDATE_QUERY}
@@ -131,7 +131,7 @@ x-quorum-def-node1:
 x-quorum-def:
   &quorum-def
   restart: "on-failure"
-  image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:21.7.1}"
+  image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:21.7}"
   expose:
     - "21000"
     - "50400"
@@ -177,7 +177,7 @@ x-quorum-def:
       if [ "${QUORUM_CONSENSUS:-istanbul}" == "istanbul" ]; then
         GENESIS_FILE="/examples/istanbul-genesis.json"
         #set the extradata for 4 nodes
-        UPDATE_QUERY=$${UPDATE_QUERY}' | .extraData = "0x0000000000000000000000000000000000000000000000000000000000000000f89af85494d8dba507e85f116b1f7e231ca8525fc9008a6966946571d97f340c8495b661a823f2c2145ca47d63c294e36cbeb565b061217930767886474e3cde903ac594f512a992f3fb749857d758ffda1330e590fa915eb8410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c0"'
+        UPDATE_QUERY=$${UPDATE_QUERY}' | .extraData = "0xf87aa00000000000000000000000000000000000000000000000000000000000000000f85494d8dba507e85f116b1f7e231ca8525fc9008a6966946571d97f340c8495b661a823f2c2145ca47d63c294e36cbeb565b061217930767886474e3cde903ac594f512a992f3fb749857d758ffda1330e590fa915ec080c0"'
       fi
       MPS_GENESIS_FILE=$${DDIR}/mps-genesis.json
       echo "JQ Update Query:" $${UPDATE_QUERY}
@@ -208,7 +208,7 @@ x-quorum-def:
         ${QUORUM_GETH_ARGS:-} $${GETH_ARGS_${QUORUM_CONSENSUS:-istanbul}}
 x-tx-manager-def-node1:
   &tx-manager-def-node1
-  image: "${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7.2}"
+  image: "${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7}"
   expose:
     - "9000"
     - "9080"
@@ -230,7 +230,7 @@ x-tx-manager-def-node1:
       DDIR=/qdata/tm
       rm -rf $${DDIR}
       mkdir -p $${DDIR}
-      DOCKER_IMAGE="${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7.2}"
+      DOCKER_IMAGE="${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7}"
       TX_MANAGER=$$(echo $${DOCKER_IMAGE} | sed 's/^.*\/\(.*\):.*$$/\1/g')
       echo "TxManager: $${TX_MANAGER}"
       case $${TX_MANAGER}
@@ -385,7 +385,7 @@ x-tx-manager-def-node1:
       esac
 x-tx-manager-def:
   &tx-manager-def
-  image: "${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7.2}"
+  image: "${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7}"
   expose:
     - "9000"
     - "9080"
@@ -407,7 +407,7 @@ x-tx-manager-def:
       DDIR=/qdata/tm
       rm -rf $${DDIR}
       mkdir -p $${DDIR}
-      DOCKER_IMAGE="${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7.2}"
+      DOCKER_IMAGE="${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7}"
       TX_MANAGER=$$(echo $${DOCKER_IMAGE} | sed 's/^.*\/\(.*\):.*$$/\1/g')
       echo "TxManager: $${TX_MANAGER}"
       case $${TX_MANAGER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # The following environment variables are substituted if present
 # * QUORUM_CONSENSUS: default to istanbul
-# * QUORUM_DOCKER_IMAGE: default to quorumengineering/quorum:21.4
-# * QUORUM_TX_MANAGER_DOCKER_IMAGE: default to quorumengineering/tessera:21.7
+# * QUORUM_DOCKER_IMAGE: default to quorumengineering/quorum:21.7.1
+# * QUORUM_TX_MANAGER_DOCKER_IMAGE: default to quorumengineering/tessera:21.7.2
 # * QUORUM_GETH_ARGS: extra geth arguments to be included when running geth
 # To use Constellation, set QUORUM_TX_MANAGER_DOCKER_IMAGE to Constellation docker image,
 # e.g.: QUORUM_TX_MANAGER_DOCKER_IMAGE=quorumengineering/constellation:0.3.2 docker-compose up -d
@@ -10,7 +10,7 @@ version: "3.6"
 x-quorum-def:
   &quorum-def
   restart: "on-failure"
-  image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:21.7.0}"
+  image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:21.7.1}"
   expose:
     - "21000"
     - "50400"
@@ -79,7 +79,7 @@ x-quorum-def:
         ${QUORUM_GETH_ARGS:-} $${GETH_ARGS_${QUORUM_CONSENSUS:-istanbul}}
 x-tx-manager-def:
   &tx-manager-def
-  image: "${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7}"
+  image: "${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7.2}"
   expose:
     - "9000"
     - "9080"
@@ -101,7 +101,7 @@ x-tx-manager-def:
       DDIR=/qdata/tm
       rm -rf $${DDIR}
       mkdir -p $${DDIR}
-      DOCKER_IMAGE="${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7}"
+      DOCKER_IMAGE="${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7.2}"
       TX_MANAGER=$$(echo $${DOCKER_IMAGE} | sed 's/^.*\/\(.*\):.*$$/\1/g')
       echo "TxManager: $${TX_MANAGER}"
       case $${TX_MANAGER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # The following environment variables are substituted if present
 # * QUORUM_CONSENSUS: default to istanbul
-# * QUORUM_DOCKER_IMAGE: default to quorumengineering/quorum:21.7.1
-# * QUORUM_TX_MANAGER_DOCKER_IMAGE: default to quorumengineering/tessera:21.7.2
+# * QUORUM_DOCKER_IMAGE: default to quorumengineering/quorum:21.7
+# * QUORUM_TX_MANAGER_DOCKER_IMAGE: default to quorumengineering/tessera:21.7
 # * QUORUM_GETH_ARGS: extra geth arguments to be included when running geth
 # To use Constellation, set QUORUM_TX_MANAGER_DOCKER_IMAGE to Constellation docker image,
 # e.g.: QUORUM_TX_MANAGER_DOCKER_IMAGE=quorumengineering/constellation:0.3.2 docker-compose up -d
@@ -10,7 +10,7 @@ version: "3.6"
 x-quorum-def:
   &quorum-def
   restart: "on-failure"
-  image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:21.7.1}"
+  image: "${QUORUM_DOCKER_IMAGE:-quorumengineering/quorum:21.7}"
   expose:
     - "21000"
     - "50400"
@@ -79,7 +79,7 @@ x-quorum-def:
         ${QUORUM_GETH_ARGS:-} $${GETH_ARGS_${QUORUM_CONSENSUS:-istanbul}}
 x-tx-manager-def:
   &tx-manager-def
-  image: "${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7.2}"
+  image: "${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7}"
   expose:
     - "9000"
     - "9080"
@@ -101,7 +101,7 @@ x-tx-manager-def:
       DDIR=/qdata/tm
       rm -rf $${DDIR}
       mkdir -p $${DDIR}
-      DOCKER_IMAGE="${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7.2}"
+      DOCKER_IMAGE="${QUORUM_TX_MANAGER_DOCKER_IMAGE:-quorumengineering/tessera:21.7}"
       TX_MANAGER=$$(echo $${DOCKER_IMAGE} | sed 's/^.*\/\(.*\):.*$$/\1/g')
       echo "TxManager: $${TX_MANAGER}"
       case $${TX_MANAGER}

--- a/examples/7nodes/README.md
+++ b/examples/7nodes/README.md
@@ -143,6 +143,33 @@ private.set(6, {from:web3.eth.accounts[0], gas: 0x47b760, privacyFlag:1, private
 ```
 For further details about [privacy enhancements](https://docs.goquorum.consensys.net/en/latest/Concepts/Privacy/PrivacyEnhancements/) please consult the latest go-quorum documentation.  
 
+### Private Transactions using Privacy Marker Transactions
+
+#### Set up
+
+Before running the relevant startup script, set the `QUORUM_GETH_ARGS` environment variable with the command line argument to enable the creation of privacy marker transactions.
+The `genesis.json` is already set up to support processing of privacy marker transactions from block 0 (`privacyPrecompileBlock: 0`).
+
+```
+export QUORUM_GETH_ARGS="--privacymarker.enable"
+```
+
+#### Usage
+
+Submit private transactions to the network as normal, for example using the `geth` console:
+```shell
+> loadScript('private-contract.js')
+Contract transaction send: TransactionHash: 0xdeb7058fe871b11fb544eadeeafb62de44e035fb57587d550e39f925ab87c86b waiting to be mined...
+undefined
+> Contract mined! Address: 0x180893a0ec847fa8c92786791348d7d65916acbb
+```
+
+This will return the transaction hash for the public Privacy Marker Transaction. The receipt for this can be retrieved as normal using `eth_getTransactionReceipt()`.
+
+In order to retrieve details of the underlying private transaction, you must use the functions `eth_getPrivateTransaction()` and `eth_getPrivateTransactionReceipt()`. These are only available to participants of the private transaction. Non-participants will receive an empty result.
+
+For further details about [privacy marker transactions](https://docs.goquorum.consensys.net/en/latest/Concepts/Privacy/PrivacyMarkerTransactions/) please consult the latest go-quorum documentation.
+
 ## Permissions
 
 Node Permissioning is a feature in Quorum that allows only a pre-defined set of nodes (as identified by their remotekey/enodes) to connect to the permissioned network.

--- a/examples/7nodes/clique-genesis.json
+++ b/examples/7nodes/clique-genesis.json
@@ -30,6 +30,7 @@
     "eip158Block": 0,
     "qip714Block": 100,
     "isQuorum": true,
+    "privacyPrecompileBlock": 0,
     "maxCodeSizeConfig" : [
       {
         "block" : 0,

--- a/examples/7nodes/genesis.json
+++ b/examples/7nodes/genesis.json
@@ -30,6 +30,7 @@
     "eip158Block": 0,
     "qip714Block": 20,
     "isQuorum": true,
+    "privacyPrecompileBlock": 0,
     "maxCodeSizeConfig" : [
       {
         "block" : 0,

--- a/examples/7nodes/istanbul-genesis.json
+++ b/examples/7nodes/istanbul-genesis.json
@@ -30,6 +30,7 @@
       "eip158Block": 0,
       "qip714Block": 50,
       "isQuorum": true,
+      "privacyPrecompileBlock": 0,
       "maxCodeSizeConfig" : [
         {
           "block" : 0,

--- a/examples/7nodes/raft-start.sh
+++ b/examples/7nodes/raft-start.sh
@@ -124,6 +124,7 @@ chk=`geth help | grep "allow-insecure-unlock" | wc -l`
 if (( $chk == 1 )); then
     allowSecureUnlock="--allow-insecure-unlock"
 fi
+
 ARGS="--nodiscover --nousb ${allowSecureUnlock} --verbosity ${verbosity} --networkid $NETWORK_ID --raft --raftblocktime ${blockTime} --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission,quorumExtension --emitcheckpoints --unlock 0 --password passwords.txt $QUORUM_GETH_ARGS"
 
 basePort=21000


### PR DESCRIPTION
- Added documentation to describe how to run examples with creation of Privacy Marker Transactions enabled.
- Updated genesis files so that processing of Privacy Marker Transactions is supported.
- Updated docker image versions.
- Fix broken MPT & MT examples so that they work with QBFT.
