### PR TITLE
Extra PMT and Privacy Enhancements examples

### DIFF
--- a/examples/7nodes/samples/privacy-marker-transactions.js/README.md
+++ b/examples/7nodes/samples/privacy-marker-transactions.js/README.md
@@ -1,0 +1,18 @@
+# Examples of Privacy Marker Transactions
+
+These examples demonstrate javascript code for creating a private contract, created using [Privacy Marker Transactions](https://docs.goquorum.consensys.net/en/latest/Concepts/Privacy/PrivacyMarkerTransactions/).
+
+## Running
+Please ensure that your sample network has privacy marker transactions enabled (the config section in the genesis.json has the `"privacyPrecompileBlock": 0` element and geth command line arguments include `--privacymarker.enable`). 
+
+### Raw transactions
+Run the example:
+```shell script
+$ node send-private-txn-pmt.js 
+```
+
+### Externally signed transactions
+Run the example:
+```shell script
+$ node send-externally-signed-private-txn-pmt.js 
+```

--- a/examples/7nodes/samples/privacy-marker-transactions.js/README.md
+++ b/examples/7nodes/samples/privacy-marker-transactions.js/README.md
@@ -3,16 +3,21 @@
 These examples demonstrate javascript code for creating a private contract, created using [Privacy Marker Transactions](https://docs.goquorum.consensys.net/en/latest/Concepts/Privacy/PrivacyMarkerTransactions/).
 
 ## Running
+
 Please ensure that your sample network has privacy marker transactions enabled (the config section in the genesis.json has the `"privacyPrecompileBlock": 0` element and geth command line arguments include `--privacymarker.enable`). 
 
 ### Raw transactions
+
 Run the example:
+
 ```shell script
 $ node send-private-txn-pmt.js 
 ```
 
 ### Externally signed transactions
+
 Run the example:
+
 ```shell script
 $ node send-externally-signed-private-txn-pmt.js 
 ```

--- a/examples/7nodes/samples/privacy-marker-transactions.js/send-externally-signed-private-txn-pmt.js
+++ b/examples/7nodes/samples/privacy-marker-transactions.js/send-externally-signed-private-txn-pmt.js
@@ -2,11 +2,12 @@
  * Example of creating a contract, using an externally signed privacy marker transaction.
  */
 
-const Web3 = require("web3");
-// TODO: once a web3js-quorum release is available with the PMT changes merged, then use the next line instead of local web3js-quorum
-//const Web3Quorum = require("web3js-quorum");
-const Web3Quorum = require("/Users/satpal/Documents/GitHub/web3js-quorum");
 const ethereumjsTx = require('ethereumjs-tx');
+const Web3 = require("web3");
+// TODO: this example requires a web3j-quorum release with recent changes on master to add PMT support.
+//  Until a release is available with those, you need to build web3j-quorum from master and use:
+//      const Web3Quorum = require("/path/to/local/web3js-quorum");
+const Web3Quorum = require("web3js-quorum");
 
 const web3 = new Web3Quorum(
   new Web3("http://localhost:22000"),

--- a/examples/7nodes/samples/privacy-marker-transactions.js/send-externally-signed-private-txn-pmt.js
+++ b/examples/7nodes/samples/privacy-marker-transactions.js/send-externally-signed-private-txn-pmt.js
@@ -1,0 +1,168 @@
+/*
+ * Example of creating a contract, using an externally signed privacy marker transaction.
+ */
+
+const Web3 = require("web3");
+// TODO: once a web3js-quorum release is available with the PMT changes merged, then use the next line instead of local web3js-quorum
+//const Web3Quorum = require("web3js-quorum");
+const Web3Quorum = require("/Users/satpal/Documents/GitHub/web3js-quorum");
+const ethereumjsTx = require('ethereumjs-tx');
+
+const web3 = new Web3Quorum(
+  new Web3("http://localhost:22000"),
+  {
+    privateUrl: "http://localhost:9081",
+  },
+  true
+);
+
+const TM3_PUBLIC_KEY = "1iTZde/ndBHvzhcl7V68x44Vx7pl8nwx9LqnM/AfJUg=";
+const TM7_PUBLIC_KEY = "ROAZBWtSacxXQrOe3FGAqJDyJjFePR5ce4TSIzmJ0Bc=";
+
+const decryptedAcc = web3.eth.accounts.decrypt({"address":"ed9d02e382b34818e88b88a309c7fe71e65f419d","crypto":{"cipher":"aes-128-ctr","ciphertext":"4e77046ba3f699e744acb4a89c36a3ea1158a1bd90a076d36675f4c883864377","cipherparams":{"iv":"a8932af2a3c0225ee8e872bc0e462c11"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"8ca49552b3e92f79c51f2cd3d38dfc723412c212e702bd337a3724e8937aff0f"},"mac":"6d1354fef5aa0418389b1a5d1f5ee0050d7273292a1171c51fd02f9ecff55264"},"id":"a65d1ac3-db7e-445d-a1cc-b6c5eeaa05e0","version":3}, "");
+
+const simpleStorageDeploy =
+    "0x6060604052341561000f57600080fd5b604051602080610149833981016040528080519060200190919050505b806000819055505b505b610104806100456000396000f30060606040526000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680632a1afcd914605157806360fe47b11460775780636d4ce63c146097575b600080fd5b3415605b57600080fd5b606160bd565b6040518082815260200191505060405180910390f35b3415608157600080fd5b6095600480803590602001909190505060c3565b005b341560a157600080fd5b60a760ce565b6040518082815260200191505060405180910390f35b60005481565b806000819055505b50565b6000805490505b905600a165627a7a72305820d5851baab720bba574474de3d09dbeaabc674a15f4dd93b974908476542c23f00029";
+
+const abi = [
+  {
+    constant: true,
+    inputs: [],
+    name: "storedData",
+    outputs: [{ name: "", type: "uint256" }],
+    payable: false,
+    type: "function",
+  },
+  {
+    constant: false,
+    inputs: [{ name: "x", type: "uint256" }],
+    name: "set",
+    outputs: [],
+    payable: false,
+    type: "function",
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: "get",
+    outputs: [{ name: "retVal", type: "uint256" }],
+    payable: false,
+    type: "function",
+  },
+  {
+    inputs: [{ name: "initVal", type: "uint256" }],
+    payable: false,
+    type: "constructor",
+  },
+];
+
+const simpleContract = new web3.eth.Contract(abi);
+
+const bytecodeWithInitParam = simpleContract
+    .deploy({ data: simpleStorageDeploy, arguments: [42] })
+    .encodeABI();
+
+(async () => {
+    try {
+        //Note: pmt and private txn must use same nonce value
+        const nonce = await web3.eth.getTransactionCount(decryptedAcc.address, "pending");
+        console.log("Will use nonce value: ", nonce);
+
+        //
+        //Store private payload in tessera (calls '/storeraw' and returns tessera hash)
+        //
+        const storeRawArgs = {
+            data: bytecodeWithInitParam
+        };
+        web3.ptm.storeRaw(storeRawArgs)
+            .then(tesseraPayloadHash => {
+                console.log("Stored private data in local Tessera, hash: ", tesseraPayloadHash);
+
+                //
+                //Create the private txn, sign it, serialize it and mark it as private
+                //
+                console.log("Creating private txn with nonce: ", nonce);
+                const txnParams = {
+                    gasPrice: 0,
+                    gasLimit: 4300000,
+                    value: 0,
+                    data: '0x' + tesseraPayloadHash,
+                    //### from: decryptedAcc.address,
+                    from: TM7_PUBLIC_KEY,
+                    nonce: nonce
+                };
+                const txn = new ethereumjsTx(txnParams);
+                txn.sign(Buffer.from(decryptedAcc.privateKey.substring(2), "hex"))
+                signedTxHex = '0x' + txn.serialize().toString('hex');
+                const privateSignedTx = web3.utils.setPrivate(signedTxHex)
+                const privateSignedTxHex = `0x${privateSignedTx.toString("hex")}`;
+
+                //
+                //Send private transaction to quorum for distribution to participants
+                //
+                web3.eth.distributePrivateTransaction(privateSignedTxHex, {privateFrom: TM7_PUBLIC_KEY, privateFor: [TM3_PUBLIC_KEY]})
+                    .then(tesseraPrivTxnHash => {
+                        console.log("Stored private transaction in local Tessera, hash: ", tesseraPrivTxnHash);
+
+                        web3.eth.getPrivacyPrecompileAddress()
+                            .then(precompileAddress => {
+                                console.log("Got precompile address: ", precompileAddress);
+
+                                //
+                                //Create private marker transaction (PMT), sign it and serialize it
+                                //
+                                pmtData = decryptedAcc.address.concat(tesseraPrivTxnHash.substring(2));
+                                const txnParams = {
+                                    gasPrice: 0,
+                                    gasLimit: 4300000,
+                                    value: 0,
+                                    data: pmtData,
+                                    from: decryptedAcc.address,
+                                    to: precompileAddress,
+                                    nonce: nonce
+                                };
+                                const txn = new ethereumjsTx(txnParams);
+                                txn.sign(Buffer.from(decryptedAcc.privateKey.substring(2), "hex"))
+                                signedTxHex = '0x' + txn.serialize().toString('hex');
+
+                                //
+                                //Now send the signed PMT to quorum
+                                //
+                                console.log("Sending signed privacy marker transaction to quorum, with nonce");
+                                web3.eth.sendSignedTransaction(signedTxHex)
+                                    .then(pmtReceipt => {
+                                        console.log("PMT RECEIPT: ", pmtReceipt);
+
+                                        web3.eth.getPrivateTransactionReceipt(pmtReceipt.transactionHash)
+                                            .then(receipt => {
+                                                console.log("PRIVATE TXN RECEIPT: ", receipt);
+                                                contractAddressPrivate = receipt.contractAddress;
+                                                console.log("contract address: ", receipt.contractAddress);
+                                            })
+                                            .catch(error => {
+                                                console.log("ERROR: getPrivateTransactionReceipt() failed: ", error)
+                                            });
+                                    })
+                                    .catch(error => {
+                                        console.log("ERROR: sendSignedTransaction() failed for PMT: ", error)
+                                    });
+
+                            })
+                            .catch(error => {
+                                console.log("ERROR: Could not get precompile address: ", error)
+                            });
+
+                    })
+                    .catch(error => {
+                        console.log("ERROR: Could not distribute private transaction: ", error)
+                    });
+
+            })
+            .catch(error => {
+                console.log("ERROR: Could not store payload in tessera: ", error)
+            });
+    } catch (error) {
+        console.log("Caught error :>> ", error);
+        return error;
+    }
+})();

--- a/examples/7nodes/samples/privacy-marker-transactions.js/send-private-txn-pmt.js
+++ b/examples/7nodes/samples/privacy-marker-transactions.js/send-private-txn-pmt.js
@@ -3,9 +3,11 @@
  */
 
 const Web3 = require("web3");
-// TODO: once a web3js-quorum release is available with the PMT changes merged, then use the next line instead of local web3js-quorum
+// TODO: This example relies on a change introduced into web3js-quorum in this PR: https://github.com/ConsenSys/web3js-quorum/pull/25
+// TODO: Until that PR has been merged and released, you will need to checkout the branch locally and specify the path to it in the require statement below.
+// TODO: Once the PR has been merged and released then the commented out line can be restored and used instead.
 //const Web3Quorum = require("web3js-quorum");
-const Web3Quorum = require("/Users/satpal/Documents/GitHub/web3js-quorum");
+const Web3Quorum = require("/My/local/path/to/web3js-quorum");
 
 const web3 = new Web3Quorum(
   new Web3("http://localhost:22000"),

--- a/examples/7nodes/samples/privacy-marker-transactions.js/send-private-txn-pmt.js
+++ b/examples/7nodes/samples/privacy-marker-transactions.js/send-private-txn-pmt.js
@@ -1,0 +1,87 @@
+/*
+ * Example of creating a contract, using a privacy marker transaction.
+ */
+
+const Web3 = require("web3");
+// TODO: once a web3js-quorum release is available with the PMT changes merged, then use the next line instead of local web3js-quorum
+//const Web3Quorum = require("web3js-quorum");
+const Web3Quorum = require("/Users/satpal/Documents/GitHub/web3js-quorum");
+
+const web3 = new Web3Quorum(
+  new Web3("http://localhost:22000"),
+  {
+    privateUrl: "http://localhost:9081",
+  },
+  true
+);
+
+const TM1_PUBLIC_KEY = "BULeR8JyUWhiuuCMU/HLA0Q5pzkYT+cHII3ZKBey3Bo=";
+const TM2_PUBLIC_KEY = "QfeDAys9MPDs2XHExtc84jKGHxZg/aj52DTh0vtA3Xc=";
+
+const ACCOUNT = "0xed9d02e382b34818e88b88a309c7fe71e65f419d";
+
+const simpleStorageDeploy =
+    "0x6060604052341561000f57600080fd5b604051602080610149833981016040528080519060200190919050505b806000819055505b505b610104806100456000396000f30060606040526000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680632a1afcd914605157806360fe47b11460775780636d4ce63c146097575b600080fd5b3415605b57600080fd5b606160bd565b6040518082815260200191505060405180910390f35b3415608157600080fd5b6095600480803590602001909190505060c3565b005b341560a157600080fd5b60a760ce565b6040518082815260200191505060405180910390f35b60005481565b806000819055505b50565b6000805490505b905600a165627a7a72305820d5851baab720bba574474de3d09dbeaabc674a15f4dd93b974908476542c23f00029";
+
+const abi = [
+  {
+    constant: true,
+    inputs: [],
+    name: "storedData",
+    outputs: [{ name: "", type: "uint256" }],
+    payable: false,
+    type: "function",
+  },
+  {
+    constant: false,
+    inputs: [{ name: "x", type: "uint256" }],
+    name: "set",
+    outputs: [],
+    payable: false,
+    type: "function",
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: "get",
+    outputs: [{ name: "retVal", type: "uint256" }],
+    payable: false,
+    type: "function",
+  },
+  {
+    inputs: [{ name: "initVal", type: "uint256" }],
+    payable: false,
+    type: "constructor",
+  },
+];
+
+const simpleContract = new web3.eth.Contract(abi);
+
+const bytecodeWithInitParam = simpleContract
+  .deploy({ data: simpleStorageDeploy, arguments: [42] })
+  .encodeABI();
+
+(async () => {
+  try {
+    const txCount = await web3.eth.getTransactionCount(ACCOUNT, "pending");
+
+    // Must use sendGoQuorumTransaction(), as that supports retrieval of private receipt for marker transactions.
+    web3.eth.sendGoQuorumTransaction({
+      gasPrice: "0x0",
+      gasLimit: "4300000",
+      value: "0x0",
+      data: bytecodeWithInitParam,
+      from: ACCOUNT,
+      isPrivate: true,
+      privateFrom: TM1_PUBLIC_KEY,
+      privateFor: [TM2_PUBLIC_KEY],
+      nonce: `0x${txCount}`,
+    })
+    .then(function(receipt) {
+      console.log("Got receipt: ", receipt);
+    });
+  } catch (error) {
+    console.log("Caught error :>> ", error);
+    return error;
+  }
+})();

--- a/examples/7nodes/samples/privacy-marker-transactions.js/send-private-txn-pmt.js
+++ b/examples/7nodes/samples/privacy-marker-transactions.js/send-private-txn-pmt.js
@@ -3,11 +3,11 @@
  */
 
 const Web3 = require("web3");
-// TODO: This example relies on a change introduced into web3js-quorum in this PR: https://github.com/ConsenSys/web3js-quorum/pull/25
-// TODO: Until that PR has been merged and released, you will need to checkout the branch locally and specify the path to it in the require statement below.
-// TODO: Once the PR has been merged and released then the commented out line can be restored and used instead.
-//const Web3Quorum = require("web3js-quorum");
-const Web3Quorum = require("/My/local/path/to/web3js-quorum");
+// TODO: this example requires a web3js-quorum release with changes from the pending PR
+//  which adds PMT support: https://github.com/ConsenSys/web3js-quorum/pull/25
+//  otherwise you need to build webjs-quorum from the PR branch and use:
+//      const Web3Quorum = require("/path/to/local/web3js-quorum");
+const Web3Quorum = require("web3js-quorum");
 
 const web3 = new Web3Quorum(
   new Web3("http://localhost:22000"),

--- a/examples/7nodes/samples/send-private-txn-java/README.md
+++ b/examples/7nodes/samples/send-private-txn-java/README.md
@@ -5,22 +5,39 @@
 From the send-private-txn-java folder run:
 ```
 mvn clean install
-``` 
+```
+
 ## Running
+
 Make sure to compile first. Each example should display information (hash/receipt) about the newly created transaction 
 or the error that caused the failure. 
-##### SendRawPrivateTransaction 
+
+##### SendPrivateTransaction
+
+```
+mvn exec:java -Dexec.cleanupDaemonThreads=false -Dexec.mainClass=com.quorum.web3j.example.SendPrivateTransaction
+```
+
+##### SendRawPrivateTransaction
+
 ```
 mvn exec:java -Dexec.cleanupDaemonThreads=false -Dexec.mainClass=com.quorum.web3j.example.SendRawPrivateTransaction
-
 ```
+
 ##### SendRawPrivateTransactionExternalSigning
+
 ```
 mvn exec:java -Dexec.cleanupDaemonThreads=false -Dexec.mainClass=com.quorum.web3j.example.SendRawPrivateTransactionExternalSigning
-
 ```
+
 ##### SendRawPrivateTransactionWithQTM
+
 ```
 mvn exec:java -Dexec.cleanupDaemonThreads=false -Dexec.mainClass=com.quorum.web3j.example.SendRawPrivateTransactionWithQTM
+```
 
+##### SendRawPrivateTransactionExternalSigningPrivacyMarker
+
+```
+mvn exec:java -Dexec.cleanupDaemonThreads=false -Dexec.mainClass=com.quorum.web3j.example.SendRawPrivateTransactionExternalSigningPrivacyMarker
 ```

--- a/examples/7nodes/samples/send-private-txn-java/pom.xml
+++ b/examples/7nodes/samples/send-private-txn-java/pom.xml
@@ -26,10 +26,10 @@
             <groupId>org.web3j</groupId>
             <artifactId>quorum</artifactId>
             <version>${web3j-quorum.version}</version>
-            <!-- ####### TODO: Satpal - remove next three lines #######-->
-            <!--use the next two lines when running against locally built web3j-quorum-->
+            <!-- TODO: When the privacy marker transaction changes are merged and released in web3j-quorum, then next two dependency lines can be removed. -->
+            <!-- TODO: In the meantime, you need to checkout https://github.com/QuorumEngineering/web3j-quorum/tree/feature/addPrivacyMarkerTransactions and build locally. -->
             <scope>system</scope>
-            <systemPath>/Users/satpal/Documents/GitHub/web3j-quorum/build/libs/web3j-quorum-${web3j-quorum.version}.jar</systemPath>
+            <systemPath>/My/local/path/to/web3j-quorum/build/libs/web3j-quorum-${web3j-quorum.version}.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>org.web3j</groupId>

--- a/examples/7nodes/samples/send-private-txn-java/pom.xml
+++ b/examples/7nodes/samples/send-private-txn-java/pom.xml
@@ -26,10 +26,14 @@
             <groupId>org.web3j</groupId>
             <artifactId>quorum</artifactId>
             <version>${web3j-quorum.version}</version>
-            <!-- TODO: When the privacy marker transaction changes are merged and released in web3j-quorum, then next two dependency lines can be removed. -->
-            <!-- TODO: In the meantime, you need to checkout https://github.com/QuorumEngineering/web3j-quorum/tree/feature/addPrivacyMarkerTransactions and build locally. -->
+            <!-- TODO: this example requires a web3j-quorum release with recent changes on master to add PMT support.
+                       Until a release is available with those, you need to set web3j-quorum-version to "4.8.5-SNAPSHOT",
+                       build web3j-quorum from master and use <scope> and <systemPath> lines shown below.
+                       You will also need "-Dexec.classpathScope=compile" added to "mvn exec:java" command line
+                       when running the examples.
             <scope>system</scope>
             <systemPath>/My/local/path/to/web3j-quorum/build/libs/web3j-quorum-${web3j-quorum.version}.jar</systemPath>
+            -->
         </dependency>
         <dependency>
             <groupId>org.web3j</groupId>

--- a/examples/7nodes/samples/send-private-txn-java/pom.xml
+++ b/examples/7nodes/samples/send-private-txn-java/pom.xml
@@ -14,23 +14,34 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <generated.sol.dir>${project.build.directory}/generate-sources/sol</generated.sol.dir>
 
-        <web3j-quorum.version>4.5.8</web3j-quorum.version>
+        <web3j.version>4.8.7</web3j.version>
+        <web3j-quorum.version>4.8.5</web3j-quorum.version>
         <commons-lang.version>2.6</commons-lang.version>
         <!-- plugins -->
         <web3j-maven-plugin.version>4.2.0</web3j-maven-plugin.version>
     </properties>
-    <dependencies>
 
+    <dependencies>
         <dependency>
             <groupId>org.web3j</groupId>
             <artifactId>quorum</artifactId>
             <version>${web3j-quorum.version}</version>
+            <!-- ####### TODO: Satpal - remove next three lines #######-->
+            <!--use the next two lines when running against locally built web3j-quorum-->
+            <scope>system</scope>
+            <systemPath>/Users/satpal/Documents/GitHub/web3j-quorum/build/libs/web3j-quorum-${web3j-quorum.version}.jar</systemPath>
         </dependency>
-    	<dependency>
-      	    <groupId>org.web3j</groupId>
+        <dependency>
+            <groupId>org.web3j</groupId>
             <artifactId>core</artifactId>
-            <version>${web3j-maven-plugin.version}</version>
-    	</dependency>
+            <version>${web3j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+            <version>2.12.5</version>
+        </dependency>
+
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>

--- a/examples/7nodes/samples/send-private-txn-java/src/main/java/com/quorum/web3j/example/SendPrivateTransaction.java
+++ b/examples/7nodes/samples/send-private-txn-java/src/main/java/com/quorum/web3j/example/SendPrivateTransaction.java
@@ -1,0 +1,52 @@
+package com.quorum.web3j.example;
+
+import com.quorum.example.sol.SimpleStorage;
+import org.web3j.protocol.admin.Admin;
+import org.web3j.protocol.admin.methods.response.PersonalUnlockAccount;
+import org.web3j.protocol.core.methods.response.*;
+import org.web3j.protocol.http.HttpService;
+import org.web3j.quorum.PrivacyFlag;
+import org.web3j.quorum.Quorum;
+import org.web3j.quorum.tx.ClientTransactionManager;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+
+/**
+ * Deploy a private contract using web3 generated java code and the ClientTransactionManager.
+ * Also demonstrates use of Privacy Flag and Mandatory Recipients.
+ */
+public class SendPrivateTransaction {
+    private static final String TESSERA1_PUBLIC_KEY = "BULeR8JyUWhiuuCMU/HLA0Q5pzkYT+cHII3ZKBey3Bo=";
+
+    private static final String TESSERA7_PUBLIC_KEY = "ROAZBWtSacxXQrOe3FGAqJDyJjFePR5ce4TSIzmJ0Bc=";
+
+    public static void main(String[] args) throws Exception {
+        // initialize web3j with the quorum RPC address
+        final HttpService httpService = new HttpService("http://localhost:22000");
+
+        Admin admin = Admin.build(httpService);
+        Quorum quorum = Quorum.build(httpService);
+
+        // This uses ClientTransactionManager with 'on node' signing, using the specified account.
+        final EthAccounts ethAccounts = quorum.ethAccounts().send();
+        final String ethFirstAccount = ethAccounts.getAccounts().get(0);
+        System.out.println("Using eth account " + ethAccounts.getAccounts());
+
+        final PersonalUnlockAccount personalUnlockAccount = admin.personalUnlockAccount(ethFirstAccount, "").send();
+        if (!personalUnlockAccount.accountUnlocked()) {
+            throw new IllegalStateException("Account " + ethFirstAccount + " can not be unlocked!");
+        }
+
+        ClientTransactionManager clientTransactionManager = new ClientTransactionManager(quorum, ethFirstAccount, TESSERA1_PUBLIC_KEY, Arrays.asList(TESSERA1_PUBLIC_KEY, TESSERA7_PUBLIC_KEY), PrivacyFlag.MANDATORY_FOR, Arrays.asList(TESSERA7_PUBLIC_KEY), 30, 1000);
+
+        SimpleStorage ssContract = SimpleStorage.deploy(quorum,
+                clientTransactionManager,
+                BigInteger.valueOf(0),
+                BigInteger.valueOf(4300000),
+                BigInteger.valueOf(42)).send();
+
+        System.out.println("Contract address:" + ssContract.getContractAddress());
+        System.out.println(ssContract.getTransactionReceipt());
+    }
+}

--- a/examples/7nodes/samples/send-private-txn-java/src/main/java/com/quorum/web3j/example/SendRawPrivateTransactionExternalSigningPrivacyMarker.java
+++ b/examples/7nodes/samples/send-private-txn-java/src/main/java/com/quorum/web3j/example/SendRawPrivateTransactionExternalSigningPrivacyMarker.java
@@ -1,0 +1,141 @@
+package com.quorum.web3j.example;
+
+import okhttp3.OkHttpClient;
+import org.web3j.abi.FunctionEncoder;
+import org.web3j.crypto.Credentials;
+import org.web3j.crypto.RawTransaction;
+import org.web3j.crypto.TransactionEncoder;
+import org.web3j.crypto.WalletUtils;
+import org.web3j.protocol.core.DefaultBlockParameterName;
+import org.web3j.protocol.core.methods.response.*;
+import org.web3j.protocol.http.HttpService;
+import org.web3j.quorum.PrivacyFlag;
+import org.web3j.quorum.Quorum;
+import org.web3j.quorum.enclave.Enclave;
+import org.web3j.quorum.enclave.SendResponse;
+import org.web3j.quorum.enclave.Tessera;
+import org.web3j.quorum.enclave.protocol.EnclaveService;
+import org.web3j.quorum.methods.response.EthAddress;
+import org.web3j.quorum.tx.response.QuorumPollingTransactionReceiptProcessor;
+import org.web3j.rlp.*;
+import org.web3j.tx.response.PollingTransactionReceiptProcessor;
+import org.web3j.utils.Numeric;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+
+/**
+ * Deploy a private contract using an externally signed Privacy Marker Transaction.
+ * Also demonstrates use of Privacy Flag and Mandatory Recipients.
+ */
+public class SendRawPrivateTransactionExternalSigningPrivacyMarker {
+    private static final String TESSERA1_PUBLIC_KEY = "BULeR8JyUWhiuuCMU/HLA0Q5pzkYT+cHII3ZKBey3Bo=";
+    private static final String TESSERA3_PUBLIC_KEY = "1iTZde/ndBHvzhcl7V68x44Vx7pl8nwx9LqnM/AfJUg=";
+    private static final String TESSERA7_PUBLIC_KEY = "ROAZBWtSacxXQrOe3FGAqJDyJjFePR5ce4TSIzmJ0Bc=";
+
+    public static void main(String[] args) throws Exception {
+        // initialize web3j with the quorum RPC address
+        Quorum quorum = Quorum.build(new HttpService("http://localhost:22000"));
+        // initialize the enclave service using the tessera ThirdParty app URL
+        EnclaveService enclaveService = new EnclaveService("http://localhost", 9081, new OkHttpClient());
+        Enclave enclave = new Tessera(enclaveService, quorum);
+
+        Credentials credentials = WalletUtils.loadCredentials("", "../../keys/key1");
+
+        // Get address of the privacy precompile contract
+        EthAddress precompileAddress = quorum.ethGetPrivacyPrecompileAddress().send();
+        System.out.println("Retrieved precompile address:" + precompileAddress.getAddress());
+
+        // build the raw transaction payload
+        final int valueToSet = 1961;
+        String simpleStorageContractBytecode = "608060405234801561001057600080fd5b506040516101073803806101078339818101604052602081101561003357600080fd5b505160005560c1806100466000396000f3fe6080604052348015600f57600080fd5b5060043610603c5760003560e01c80632a1afcd914604157806360fe47b11460595780636d4ce63c146075575b600080fd5b6047607b565b60408051918252519081900360200190f35b607360048036036020811015606d57600080fd5b50356081565b005b60476086565b60005481565b600055565b6000549056fea265627a7a7231582086cef7b6c960e37608f020bdfdac3e51568d5333325973879fae2418aa2c307464736f6c63430005110032";
+        String encodedConstructor = FunctionEncoder.encodeConstructor(Arrays.asList(new org.web3j.abi.datatypes.generated.Uint256(valueToSet)));
+        String binaryAndInitCode = simpleStorageContractBytecode + encodedConstructor;
+
+        // store the raw transaction payload in tessera
+        SendResponse storeRawResponse = enclave.storeRawRequest(
+                Base64.getEncoder().encodeToString(Numeric.hexStringToByteArray(binaryAndInitCode)),
+                TESSERA1_PUBLIC_KEY, Collections.emptyList());
+        System.out.println("Stored payload in Tessera, hash:" + storeRawResponse.getKey());
+        String tesseraPayloadHash = Numeric.toHexString(Base64.getDecoder().decode(storeRawResponse.getKey()));
+
+        // find the current nonce for the account (for use in the next transaction)
+        EthGetTransactionCount txCount = quorum.ethGetTransactionCount(credentials.getAddress(), DefaultBlockParameterName.LATEST).send();
+        int nonce = txCount.getTransactionCount().intValue();
+
+        // build and sign private transaction
+        RawTransaction rawPrivateTransaction = RawTransaction.createContractTransaction(BigInteger.valueOf(nonce),
+                BigInteger.valueOf(0), BigInteger.valueOf(4300000), BigInteger.valueOf(0), tesseraPayloadHash);
+        byte[] signedTxBytes = signTransactionUsingWeb3j(rawPrivateTransaction, credentials);
+        signedTxBytes = setPrivate(signedTxBytes);  // set the private flag for the signed transaction
+        String signedTxHex = Numeric.toHexString(signedTxBytes);
+
+        // distribute the signed private transaction to participants, with Mandatory Recipient
+        EthSendTransaction storePrivateTxnResponse = quorum.ethDistributePrivateTransaction(signedTxHex, Arrays.asList(TESSERA3_PUBLIC_KEY, TESSERA7_PUBLIC_KEY), PrivacyFlag.MANDATORY_FOR, Arrays.asList(TESSERA7_PUBLIC_KEY)).send();
+        if (storePrivateTxnResponse.hasError()) {
+            throw new Exception("Distribute Private Transaction failed, error = " + storePrivateTxnResponse.getError().getMessage());
+        }
+        String privateTxnHash = storePrivateTxnResponse.getTransactionHash();
+        System.out.println("Private Transaction distributed, hash:" + privateTxnHash);
+
+        // build and sign privacy marker transaction
+        RawTransaction privacyMarkerTransaction = RawTransaction.createTransaction(BigInteger.valueOf(nonce),
+                BigInteger.valueOf(0), BigInteger.valueOf(4300000), precompileAddress.getAddress(), privateTxnHash);
+        byte[] signedPMTBytes = signTransactionUsingWeb3j(privacyMarkerTransaction, credentials);
+        String signedPMTHex = Numeric.toHexString(signedPMTBytes);
+
+        // send the privacy marker transaction to quorum
+        EthSendTransaction ethSendTransaction = quorum.ethSendRawTransaction(signedPMTHex).send();
+
+        String txHash = ethSendTransaction.getTransactionHash();
+        if (txHash == null) {
+            throw new Exception("Transaction failed (null txHash): check geth logs for cause");
+        }
+
+        // poll for the privacy marker transaction receipt (use Quorum poller, as that returns receipt with isPrivacyMarkerTransaction field)
+        PollingTransactionReceiptProcessor pollingTransactionReceiptProcessor = new QuorumPollingTransactionReceiptProcessor(quorum, 1000, 10);
+        TransactionReceipt pmtReceipt = pollingTransactionReceiptProcessor.waitForTransactionReceipt(txHash);
+        System.out.println("Privacy Marker Transaction completed, receipt =\n" + pmtReceipt);
+        // get the private transaction receipt
+        EthGetTransactionReceipt privateTransactionReceipt = quorum.ethGetPrivateTransactionReceipt(txHash).send();
+        System.out.println("Private transaction receipt =\n" + privateTransactionReceipt.getResult());
+    }
+
+    // REPLACE THIS WITH YOUR MECHANISM FOR SIGNING TRANSACTIONS
+    private static byte[] signTransactionUsingWeb3j(RawTransaction rawTransaction, Credentials credentials){
+        return TransactionEncoder.signMessage(rawTransaction, credentials);
+    }
+
+    // If the byte array RLP decodes to a list of size >= 1 containing a list of size >= 3
+    // then find the 3rd element from the last. If the element is a RlpString of size 1 then
+    // it should be the V component from the SignatureData structure -> mark the transaction as private.
+    // If any of of the above checks fails then return the original byte array.
+    private static byte[] setPrivate(byte[] message){
+        byte[] result = message;
+        RlpList rlpWrappingList = RlpDecoder.decode(message);
+        if (!rlpWrappingList.getValues().isEmpty()) {
+            RlpType rlpListObj = rlpWrappingList.getValues().get(0);
+            if (rlpListObj instanceof RlpList) {
+                RlpList rlpList = (RlpList) rlpListObj;
+                int rlpListSize = rlpList.getValues().size();
+                if (rlpListSize > 3) {
+                    RlpType vFieldObj = rlpList.getValues().get(rlpListSize-3);
+                    if (vFieldObj instanceof RlpString) {
+                        RlpString vField = (RlpString) vFieldObj;
+                        if (1 == vField.getBytes().length) {
+                            if (vField.getBytes()[0] == 28){
+                                vField.getBytes()[0] = 38;
+                            } else {
+                                vField.getBytes()[0] = 37;
+                            }
+                            result = RlpEncoder.encode(rlpList);
+                        }
+                    }
+                }
+            }
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
Adding further examples to demonstrate usage of `web3j-quorum` and `web3js-quorum`. In particular for Privacy Enhancements and Privacy Marker Transactions.

Note that these examples require recent changes to `web3j-quorum` and `web3js-quorum`, which (at the time of creating this PR) are not yet released. Until those changes are added to official releases, there are a couple of 'TODO's that explain how to use a local build from the relevant branch.